### PR TITLE
Fix player letterboxing and add mobile edge-to-edge mode

### DIFF
--- a/web/src/components/PlayerModal.jsx
+++ b/web/src/components/PlayerModal.jsx
@@ -25,10 +25,18 @@ export default function PlayerModal({
   const hotkeyMapRef = useRef(new Map())
   const screenshotInFlightRef = useRef(false)
   const screenshotNoticeTimerRef = useRef(null)
+  // App 侧传入的 onClose / onPlaybackError 通常是内联箭头函数，每次渲染引用都会变。
+  // 若直接作为 effect 依赖，会导致播放器反复 dispose/重建（video.js 会移除 DOM，
+  // 重建时拿到已脱离文档的元素而失败，播放区变黑），因此用 ref 保存最新回调。
+  const onCloseRef = useRef(onClose)
+  onCloseRef.current = onClose
+  const onPlaybackErrorRef = useRef(onPlaybackError)
+  onPlaybackErrorRef.current = onPlaybackError
   const [playbackInfo, setPlaybackInfo] = useState(null)
   const [playbackError, setPlaybackError] = useState('')
   const [loadingPlayback, setLoadingPlayback] = useState(false)
   const [screenshotNotice, setScreenshotNotice] = useState(false)
+  const [videoSize, setVideoSize] = useState(null) // { width, height } of the source video
   const normalizedHotkeys = useMemo(() => parsePlayerHotkeys(hotkeys), [hotkeys])
   const selectedSource = useMemo(() => {
     if (!playbackInfo?.sources?.length) return null
@@ -56,6 +64,7 @@ export default function PlayerModal({
       setPlaybackError('')
       setLoadingPlayback(false)
       setScreenshotNotice(false)
+      setVideoSize(null)
       return
     }
 
@@ -64,6 +73,7 @@ export default function PlayerModal({
     setPlaybackError('')
     setPlaybackInfo(null)
     setScreenshotNotice(false)
+    setVideoSize(null)
 
     fetchPlaybackInfo(video.id, { locationId: video.location_id })
       .then((info) => {
@@ -74,7 +84,7 @@ export default function PlayerModal({
         if (cancelled) return
         const message = getErrorMessage(err)
         setPlaybackError(message)
-        onPlaybackError?.(message)
+        onPlaybackErrorRef.current?.(message)
       })
       .finally(() => {
         if (cancelled) return
@@ -84,7 +94,7 @@ export default function PlayerModal({
     return () => {
       cancelled = true
     }
-  }, [onPlaybackError, video])
+  }, [video])
 
   useEffect(() => {
     if (!video || !videoRef.current || !selectedSource?.src) return
@@ -204,7 +214,7 @@ export default function PlayerModal({
         }
         case 'Escape':
           markHandled()
-          onClose()
+          onCloseRef.current()
           break
         default:
           return
@@ -213,6 +223,16 @@ export default function PlayerModal({
 
     const focusPlayer = () => {
       playerEl?.focus({ preventScroll: true })
+    }
+    // video.js 在 data-vjs-player 包装下会用新的 .vjs-tech 元素替换原 <video> 标签，
+    // 因此不能从 videoRef.current 读尺寸（恒为 0），必须走 player API。
+    // 同时监听 resize：HLS 等流在 loadedmetadata 时可能还拿不到分辨率，稍后会再触发。
+    const handleDimensions = () => {
+      const width = player.videoWidth()
+      const height = player.videoHeight()
+      if (width > 0 && height > 0) {
+        setVideoSize({ width, height })
+      }
     }
     const applyStartTime = () => {
       const nextStartTime = Number(startTime)
@@ -240,46 +260,68 @@ export default function PlayerModal({
     })
     player.on('fullscreenchange', focusPlayer)
     player.on('volumechange', handleVolumeChange)
+    player.on('loadedmetadata', handleDimensions)
+    player.on('resize', handleDimensions)
 
     return () => {
       window.removeEventListener('keydown', handleKeyDown, true)
       player.off('fullscreenchange', focusPlayer)
       player.off('volumechange', handleVolumeChange)
+      player.off('loadedmetadata', handleDimensions)
+      player.off('resize', handleDimensions)
       playerRef.current?.dispose()
       playerRef.current = null
     }
-  }, [video, startTime, onClose, selectedSource])
+  }, [video, startTime, selectedSource])
 
   if (!video) return null
 
   const displayName = getVideoDisplayName(video)
+  const aspectRatio =
+    videoSize && videoSize.height > 0 ? videoSize.width / videoSize.height : 16 / 9
 
   return (
-    <div className="fixed inset-0 z-[1700] flex items-center justify-center bg-black/70">
-      <div className="relative mx-4 w-full max-w-6xl rounded-lg bg-white shadow-lg">
+    <div className="fixed inset-0 z-[1700] flex items-center justify-center bg-black/70 pointer-coarse:bg-black">
+      {/*
+        桌面端：白色卡片包裹，标题与关闭按钮在卡片内；
+        移动端（触摸设备，含横屏）：隐藏白卡片边框，视频按比例贴边（100vw/100dvh，不超出不拉伸），标题悬浮在视频上方。
+        宽度公式在 .player-card 的媒体查询中，比例通过 --player-ar 传入。
+      */}
+      <div
+        className="player-card relative mx-4 rounded-lg bg-white shadow-lg pointer-coarse:mx-0 pointer-coarse:rounded-none pointer-coarse:bg-black pointer-coarse:shadow-none"
+        style={{ '--player-ar': `${aspectRatio}` }}
+      >
         <button
           aria-label={zh('关闭', 'Close')}
           onClick={onClose}
-          className="absolute right-3 top-3 rounded-full bg-black/60 px-2 py-1 text-sm text-white hover:bg-black/80"
+          className="absolute right-3 top-3 z-20 rounded-full bg-black/60 px-2 py-1 text-sm text-white hover:bg-black/80"
         >
           ×
         </button>
-        <div className="flex flex-col gap-4 p-4">
-          <h2 className="truncate text-lg font-semibold" title={displayName}>
+        <div className="flex flex-col gap-4 p-4 pointer-coarse:gap-0 pointer-coarse:p-0">
+          <h2
+            className="truncate pr-10 text-lg font-semibold pointer-coarse:absolute pointer-coarse:inset-x-0 pointer-coarse:top-0 pointer-coarse:z-10 pointer-coarse:bg-gradient-to-b pointer-coarse:from-black/60 pointer-coarse:to-transparent pointer-coarse:px-12 pointer-coarse:pb-5 pointer-coarse:pt-2 pointer-coarse:text-sm pointer-coarse:font-medium pointer-coarse:text-white"
+            title={displayName}
+          >
             {displayName}
           </h2>
-          <div className="player-shell relative w-full bg-black">
+          <div
+            className="player-shell relative w-full bg-black"
+            style={{
+              aspectRatio: videoSize ? `${videoSize.width} / ${videoSize.height}` : '16 / 9',
+            }}
+          >
             {screenshotNotice ? (
               <div className="pointer-events-none absolute left-3 top-3 z-10 rounded bg-black/75 px-3 py-1.5 text-sm font-medium text-white shadow">
                 {zh('截图成功', 'Screenshot saved')}
               </div>
             ) : null}
             {loadingPlayback ? (
-              <div className="flex aspect-video items-center justify-center text-sm text-white">
+              <div className="flex h-full w-full items-center justify-center text-sm text-white">
                 {zh('加载播放信息中…', 'Loading playback info...')}
               </div>
             ) : playbackError ? (
-              <div className="flex aspect-video items-center justify-center px-6 text-center text-sm text-red-200">
+              <div className="flex h-full w-full items-center justify-center px-6 text-center text-sm text-red-200">
                 {playbackError}
               </div>
             ) : (

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -297,25 +297,33 @@ body.has-page-scroll .sticky-pagination {
     0 1px 2px rgba(15, 23, 42, 0.16);
 }
 
+.player-card {
+  /* 视频比例由 React 通过 --player-ar 传入；宽度公式驱动等比例缩放 */
+  --player-ar: 16 / 9;
+  width: min(80vw, calc((80vh - 5rem) * var(--player-ar) + 2rem));
+}
+
+/* 移动端（触摸设备）：贴边全屏，隐藏白卡片边框；标题悬浮不占布局，因此无需预留标题高度。
+   用 pointer: coarse 而非宽度断点，覆盖横屏手机（宽度可能超过 640px） */
+@media (pointer: coarse) {
+  .player-card {
+    width: min(100vw, calc(100vh * var(--player-ar)));
+  }
+  @supports (height: 100dvh) {
+    .player-card {
+      width: min(100vw, calc(100dvh * var(--player-ar)));
+    }
+  }
+}
+
 .player-shell {
-  --player-controls-height: 30px;
-  height: 75vh;
-  padding-bottom: var(--player-controls-height);
-  box-sizing: border-box;
-  overflow: visible;
+  position: relative;
+  background: #000;
 }
 
 .player-shell .video-js {
   width: 100%;
   height: 100%;
-}
-
-.player-shell .vjs-control-bar {
-  transform: translateY(100%);
-  opacity: 1 !important;
-  visibility: visible !important;
-  pointer-events: auto !important;
-  display: flex !important;
 }
 
 .player-shell .vjs-volume-panel,
@@ -334,10 +342,6 @@ body.has-page-scroll .sticky-pagination {
   height: 3em;
   margin: 0;
   transition: none;
-}
-
-.player-shell .video-js.vjs-fullscreen .vjs-control-bar {
-  transform: none;
 }
 
 .skeuo-tag {

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -4,5 +4,11 @@ export default {
   theme: {
     extend: {},
   },
-  plugins: [],
+  plugins: [
+    // Tailwind v3 没有内置 pointer-coarse 变体（v4 才有），这里手动注册：
+    // 匹配触摸设备（移动端），用于播放器移动端贴边全屏样式
+    ({ addVariant }) => {
+      addVariant('pointer-coarse', '@media (pointer: coarse)')
+    },
+  ],
 }


### PR DESCRIPTION
Fixes the video player showing black bars for non-16:9 videos and adds an edge-to-edge layout on mobile devices.

## Changes

### Letterboxing fix
- **Read video dimensions via the player API instead of `videoRef.current`**: under `data-vjs-player`, video.js replaces the original `<video>` tag with a new `.vjs-tech` element, so reading `videoRef.current.videoWidth` always returned 0 and the modal stayed at the 16:9 fallback, causing black bars for 4:3 / 9:16 / SAR videos.
- **Size the player shell by the real video aspect ratio** (`player.videoWidth()/videoHeight()`), also listening to `resize` for streams whose metadata arrives late (e.g. HLS).
- **Remove the fixed `height: 75vh` from `.player-shell`** which overrode the inline `aspect-ratio` (per CSS spec, `aspect-ratio` is ignored when height is not auto).

### Player lifecycle stability
- Keep `onClose` / `onPlaybackError` in refs. App passes inline arrow functions, so their identity changes on every render; using them as effect deps disposed and recreated the player repeatedly. video.js removes the DOM on dispose and React is unaware, so recreation received a detached element and failed, leaving an empty black shell.

### Mobile (touch devices) edge-to-edge mode
- Register a `pointer-coarse` variant for Tailwind v3 (built-in only in v4).
- On `pointer: coarse` devices (works in landscape too, unlike width breakpoints): hide the white card (no border, radius, shadow), fit the video edge-to-edge within `100vw / 100dvh` without cropping or stretching (ratio preserved), and overlay the title on top of the video.

## Verification

Tested in headless Chrome with real React + Tailwind + video.js stack and CDP device emulation:

| Scenario | Result |
|---|---|
| 16:9 video | shell/player/video rects identical, exact 1.7778 ratio |
| 4:3 video | exact 1.3333 ratio, no bars |
| 9:16 portrait | exact 0.5625 ratio, no bars |
| Mobile portrait 390x844 + 9:16 | flush width, exact ratio, within viewport |
| Mobile landscape 844x390 + 16:9 | flush height, exact ratio |
| Control bar shown/hidden | shell height unchanged (no layout shift) |
| App re-renders (inline callbacks) | player stays alive, no recreate loop |