### PR TITLE
支持目录树多级子目录的展开与隐藏过滤

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,8 @@ release/
 temp
 internal/bin/
 bin
+start.bat
+
+# Local agent configs (machine-specific, may contain secrets)
+.mcp.json
+.pi/

--- a/cmd/hostagent/main.go
+++ b/cmd/hostagent/main.go
@@ -1,0 +1,139 @@
+// Command hostagent runs a tiny HTTP service on the host machine that opens
+// files with the host's default applications. It is used by JavBoss instances
+// running inside Docker containers: the container forwards "open with system
+// player" and "reveal in folder" requests to this agent via
+// host.docker.internal, and the agent executes them on the host.
+//
+// Configuration:
+//
+//	JAVBOSS_AGENT_HOST  listen address (default 0.0.0.0)
+//	JAVBOSS_AGENT_PORT  listen port (default 17655)
+//	JAVBOSS_AGENT_TOKEN shared bearer token; when empty, no auth is required
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"javboss/internal/common/logging"
+	"javboss/internal/util"
+)
+
+const defaultPort = "17655"
+
+type openRequest struct {
+	Path string `json:"path"`
+}
+
+func main() {
+	host := envOr("JAVBOSS_AGENT_HOST", "0.0.0.0")
+	port := envOr("JAVBOSS_AGENT_PORT", defaultPort)
+	token := strings.TrimSpace(os.Getenv("JAVBOSS_AGENT_TOKEN"))
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/health", handleHealth)
+	mux.HandleFunc("POST /api/open", handleOpen)
+	mux.HandleFunc("POST /api/reveal", handleReveal)
+
+	handler := withAuth(token, mux)
+	addr := net.JoinHostPort(host, port)
+	server := &http.Server{
+		Addr:              addr,
+		Handler:           handler,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	log.Printf("javboss-host-agent listening on http://%s (auth: %v)", addr, token != "")
+	if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		log.Fatalf("javboss-host-agent: %v", err)
+	}
+}
+
+func envOr(name, fallback string) string {
+	if value := strings.TrimSpace(os.Getenv(name)); value != "" {
+		return value
+	}
+	return fallback
+}
+
+func withAuth(token string, next http.Handler) http.Handler {
+	if token == "" {
+		return next
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		expected := "Bearer " + token
+		if !constantTimeEqual(auth, expected) {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func constantTimeEqual(a, b string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	var diff byte
+	for i := 0; i < len(a); i++ {
+		diff |= a[i] ^ b[i]
+	}
+	return diff == 0
+}
+
+func handleHealth(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+func handleOpen(w http.ResponseWriter, r *http.Request) {
+	handleFileAction(w, r, "open", util.OpenFile)
+}
+
+func handleReveal(w http.ResponseWriter, r *http.Request) {
+	handleFileAction(w, r, "reveal", util.RevealFile)
+}
+
+func handleFileAction(w http.ResponseWriter, r *http.Request, action string, fn func(string) error) {
+	req, err := decodeOpenRequest(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err := fn(req.Path); err != nil {
+		logging.Error("host agent %s %q: %v", action, req.Path, err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	logging.Info("host agent %s %q", action, req.Path)
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+func decodeOpenRequest(r *http.Request) (*openRequest, error) {
+	body, err := io.ReadAll(io.LimitReader(r.Body, 16*1024))
+	if err != nil {
+		return nil, fmt.Errorf("read request body: %w", err)
+	}
+	var req openRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("invalid JSON body: %w", err)
+	}
+	if strings.TrimSpace(req.Path) == "" {
+		return nil, errors.New("path is required")
+	}
+	return &req, nil
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(payload)
+}

--- a/internal/db/directories.go
+++ b/internal/db/directories.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"javboss/internal/common"
@@ -81,6 +82,123 @@ func GetDirectory(ctx context.Context, id int64) (*models.Directory, error) {
 		return nil, fmt.Errorf("get directory: %w", err)
 	}
 	return &dir, nil
+}
+
+// DirectorySubdirectory summarizes one first-level subdirectory under a root
+// directory together with its active video count.
+// DirectorySubdirectory is one node of the directory tree. Name is the directory
+// name at this level, Path is its full path relative to the root directory
+// (slash-separated), VideoCount is the total number of videos in the subtree
+// (direct files plus all descendants), DirectVideoCount is the number of videos
+// directly inside this directory, and Subdirectories are the child nodes.
+type DirectorySubdirectory struct {
+	Name             string                  `json:"name"`
+	Path             string                  `json:"path"`
+	VideoCount       int64                   `json:"video_count"`
+	DirectVideoCount int64                   `json:"direct_video_count"`
+	Subdirectories   []DirectorySubdirectory `json:"subdirectories"`
+}
+
+// DirectorySubdirectories summarizes the layout of a root directory: files
+// directly at the root plus the tree of subdirectories.
+type DirectorySubdirectories struct {
+	RootVideoCount int64                  `json:"root_video_count"`
+	Subdirectories []DirectorySubdirectory `json:"subdirectories"`
+}
+
+// dirTreeNode is the internal tree node used while building the response.
+type dirTreeNode struct {
+	name     string
+	path     string
+	direct   int64
+	children map[string]*dirTreeNode
+}
+
+func buildDirTree(paths []string) *dirTreeNode {
+	root := &dirTreeNode{children: make(map[string]*dirTreeNode)}
+	for _, p := range paths {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		parts := strings.Split(p, "/")
+		current := root
+		for _, part := range parts[:len(parts)-1] {
+			if part == "" {
+				continue
+			}
+			child, ok := current.children[part]
+			if !ok {
+				childPath := part
+				if current.path != "" {
+					childPath = current.path + "/" + part
+				}
+				child = &dirTreeNode{name: part, path: childPath, children: make(map[string]*dirTreeNode)}
+				current.children[part] = child
+			}
+			current = child
+		}
+		current.direct++
+	}
+	return root
+}
+
+func dirTreeToResponse(node *dirTreeNode) DirectorySubdirectory {
+	children := make([]DirectorySubdirectory, 0, len(node.children))
+	var total int64 = node.direct
+	for _, child := range node.children {
+		converted := dirTreeToResponse(child)
+		total += converted.VideoCount
+		children = append(children, converted)
+	}
+	sort.Slice(children, func(i, j int) bool {
+		if children[i].VideoCount != children[j].VideoCount {
+			return children[i].VideoCount > children[j].VideoCount
+		}
+		return children[i].Name < children[j].Name
+	})
+	return DirectorySubdirectory{
+		Name:             node.name,
+		Path:             node.path,
+		VideoCount:       total,
+		DirectVideoCount: node.direct,
+		Subdirectories:   children,
+	}
+}
+
+// ListDirectorySubdirectories returns the number of videos directly at the root
+// and the full subdirectory tree (first and deeper levels of relative_path),
+// ordered by video count descending then name ascending at each level. Only
+// active locations are counted.
+func ListDirectorySubdirectories(ctx context.Context, directoryID int64) (DirectorySubdirectories, error) {
+	if directoryID <= 0 {
+		return DirectorySubdirectories{}, errors.New("directory id cannot be zero")
+	}
+	var paths []string
+	err := common.DB.WithContext(ctx).Raw(
+		`SELECT relative_path
+		FROM video_location
+		WHERE directory_id = ? AND COALESCE(is_delete, 0) = 0`,
+		directoryID,
+	).Scan(&paths).Error
+	if err != nil {
+		return DirectorySubdirectories{}, fmt.Errorf("list directory subdirectories: %w", err)
+	}
+	root := buildDirTree(paths)
+	result := DirectorySubdirectories{
+		RootVideoCount: root.direct,
+		Subdirectories: make([]DirectorySubdirectory, 0, len(root.children)),
+	}
+	for _, child := range root.children {
+		result.Subdirectories = append(result.Subdirectories, dirTreeToResponse(child))
+	}
+	sort.Slice(result.Subdirectories, func(i, j int) bool {
+		if result.Subdirectories[i].VideoCount != result.Subdirectories[j].VideoCount {
+			return result.Subdirectories[i].VideoCount > result.Subdirectories[j].VideoCount
+		}
+		return result.Subdirectories[i].Name < result.Subdirectories[j].Name
+	})
+	return result, nil
 }
 
 // CreateDirectory registers a new directory.

--- a/internal/db/directories_test.go
+++ b/internal/db/directories_test.go
@@ -142,14 +142,14 @@ func TestMissingDirectoryContentsRemainVisible(t *testing.T) {
 		t.Fatalf("link jav: %v", err)
 	}
 
-	items, err := ListVideos(ctx, 20, 0, nil, "", "recent", nil, []int64{dir.ID})
+	items, err := ListVideos(ctx, 20, 0, nil, "", "recent", nil, []int64{dir.ID}, nil)
 	if err != nil {
 		t.Fatalf("list videos: %v", err)
 	}
 	if len(items) != 1 || items[0].LocationID != loc.ID || !items[0].DirectoryRef.Missing {
 		t.Fatalf("missing directory video should remain visible: %#v", items)
 	}
-	count, err := CountVideos(ctx, nil, "", []int64{dir.ID})
+	count, err := CountVideos(ctx, nil, "", []int64{dir.ID}, nil)
 	if err != nil {
 		t.Fatalf("count videos: %v", err)
 	}
@@ -220,7 +220,7 @@ func TestUpdateDirectoryPathHidesExistingVideoLocations(t *testing.T) {
 		t.Fatal("existing location should be hidden immediately after directory path changes")
 	}
 
-	items, err := ListVideos(ctx, 20, 0, nil, "", "recent", nil, []int64{dir.ID})
+	items, err := ListVideos(ctx, 20, 0, nil, "", "recent", nil, []int64{dir.ID}, nil)
 	if err != nil {
 		t.Fatalf("list videos after hiding locations: %v", err)
 	}

--- a/internal/db/jav.go
+++ b/internal/db/jav.go
@@ -129,11 +129,11 @@ func GetJav(ctx context.Context, javID int64, directoryIDs []int64) (*models.Jav
 
 // SearchJav lists Jav metadata filtered by idol IDs/tag IDs/search with pagination and sorting.
 func SearchJav(ctx context.Context, idolIDs []int64, tagIDs []int64, search, sort string, limit, offset int, seed *int64, directoryIDs []int64, filterIDs ...int64) ([]models.Jav, int64, error) {
-	return SearchJavWithPrefix(ctx, idolIDs, tagIDs, search, "", sort, limit, offset, seed, directoryIDs, filterIDs...)
+	return SearchJavWithPrefix(ctx, idolIDs, tagIDs, search, "", sort, limit, offset, seed, directoryIDs, nil, filterIDs...)
 }
 
 // SearchJavWithPrefix lists Jav metadata filtered by an exact code prefix plus other filters.
-func SearchJavWithPrefix(ctx context.Context, idolIDs []int64, tagIDs []int64, search, prefix, sort string, limit, offset int, seed *int64, directoryIDs []int64, filterIDs ...int64) ([]models.Jav, int64, error) {
+func SearchJavWithPrefix(ctx context.Context, idolIDs []int64, tagIDs []int64, search, prefix, sort string, limit, offset int, seed *int64, directoryIDs []int64, closedSubdirs []ClosedSubdirectory, filterIDs ...int64) ([]models.Jav, int64, error) {
 	if limit <= 0 {
 		limit = 100
 	}
@@ -148,10 +148,10 @@ func SearchJavWithPrefix(ctx context.Context, idolIDs []int64, tagIDs []int64, s
 	sort = strings.ToLower(strings.TrimSpace(sort))
 
 	studioID, seriesID, soloOnly, favoriteGroupID := javFilterOptions(filterIDs)
-	filtered := buildJavFilter(ctx, idolIDs, tagIDs, search, prefix, directoryIDs, studioID, seriesID, soloOnly, favoriteGroupID)
+	filtered := buildJavFilter(ctx, idolIDs, tagIDs, search, prefix, directoryIDs, closedSubdirs, studioID, seriesID, soloOnly, favoriteGroupID)
 
 	// Count on a cloned query to avoid mutating the main one.
-	countBase := buildJavFilter(ctx, idolIDs, tagIDs, search, prefix, directoryIDs, studioID, seriesID, soloOnly, favoriteGroupID)
+	countBase := buildJavFilter(ctx, idolIDs, tagIDs, search, prefix, directoryIDs, closedSubdirs, studioID, seriesID, soloOnly, favoriteGroupID)
 	countQuery := countBase.Select("DISTINCT jav.id")
 	var total int64
 	if err := countQuery.Count(&total).Error; err != nil {
@@ -176,9 +176,9 @@ func SearchJavWithPrefix(ctx context.Context, idolIDs []int64, tagIDs []int64, s
 	case "release_asc":
 		order = "jav.release_unix IS NULL, jav.release_unix ASC, jav.code"
 	case "play_count", "play_count_desc":
-		order = "COALESCE((SELECT SUM(COALESCE(v.play_count, 0)) FROM video_location vl JOIN directory d ON d.id = vl.directory_id JOIN video v ON v.id = vl.video_id WHERE vl.jav_id = jav.id AND " + activeLocationWhereSQL("vl", "d") + directoryFilterSQL("vl", directoryIDs) + "), 0) DESC, jav.created_at DESC, jav.id DESC"
+		order = "COALESCE((SELECT SUM(COALESCE(v.play_count, 0)) FROM video_location vl JOIN directory d ON d.id = vl.directory_id JOIN video v ON v.id = vl.video_id WHERE vl.jav_id = jav.id AND " + activeLocationWhereSQL("vl", "d") + directoryFilterSQL("vl", directoryIDs) + closedSubdirectoryFilterSQL("vl", closedSubdirs) + "), 0) DESC, jav.created_at DESC, jav.id DESC"
 	case "play_count_asc":
-		order = "COALESCE((SELECT SUM(COALESCE(v.play_count, 0)) FROM video_location vl JOIN directory d ON d.id = vl.directory_id JOIN video v ON v.id = vl.video_id WHERE vl.jav_id = jav.id AND " + activeLocationWhereSQL("vl", "d") + directoryFilterSQL("vl", directoryIDs) + "), 0) ASC, jav.created_at ASC, jav.id ASC"
+		order = "COALESCE((SELECT SUM(COALESCE(v.play_count, 0)) FROM video_location vl JOIN directory d ON d.id = vl.directory_id JOIN video v ON v.id = vl.video_id WHERE vl.jav_id = jav.id AND " + activeLocationWhereSQL("vl", "d") + directoryFilterSQL("vl", directoryIDs) + closedSubdirectoryFilterSQL("vl", closedSubdirs) + "), 0) ASC, jav.created_at ASC, jav.id ASC"
 	case "recent_asc":
 		order = "jav.created_at ASC, jav.id ASC"
 	case "random":
@@ -210,7 +210,7 @@ func SearchJavWithPrefix(ctx context.Context, idolIDs []int64, tagIDs []int64, s
 	if err := query.Find(&items).Error; err != nil {
 		return nil, 0, fmt.Errorf("list jav: %w", err)
 	}
-	if err := attachJavLocationVideos(ctx, items, directoryIDs); err != nil {
+	if err := attachJavLocationVideos(ctx, items, directoryIDs, closedSubdirs); err != nil {
 		return nil, 0, err
 	}
 	if err := attachVisibleJavTags(ctx, items); err != nil {
@@ -292,7 +292,7 @@ func attachVisibleJavTags(ctx context.Context, items []models.Jav) error {
 	return nil
 }
 
-func attachJavLocationVideos(ctx context.Context, items []models.Jav, directoryIDs []int64) error {
+func attachJavLocationVideos(ctx context.Context, items []models.Jav, directoryIDs []int64, closedSubdirs ...[]ClosedSubdirectory) error {
 	if len(items) == 0 {
 		return nil
 	}
@@ -317,6 +317,9 @@ func attachJavLocationVideos(ctx context.Context, items []models.Jav, directoryI
 		Preload("Video").
 		Preload("Video.Tags")
 	query = applyDirectoryFilter(query, "video_location", directoryIDs)
+	if len(closedSubdirs) > 0 {
+		query = applyClosedSubdirectoryFilter(query, "video_location", closedSubdirs[0])
+	}
 	if err := query.
 		Find(&locations).Error; err != nil {
 		return fmt.Errorf("load jav video locations: %w", err)
@@ -454,12 +457,12 @@ func UpdateJav(ctx context.Context, javID int64, input JavUpdateInput, directory
 }
 
 // ListJavTags returns JAV tags with the number of works for each tag.
-func ListJavTags(ctx context.Context, directoryIDs []int64) ([]JavTagCount, error) {
-	scrapedTags, err := listJavTagsForProviders(ctx, directoryIDs, visibleScrapedJavTagProviders(), int(jav.ProviderJavBus))
+func ListJavTags(ctx context.Context, directoryIDs []int64, closedSubdirs []ClosedSubdirectory) ([]JavTagCount, error) {
+	scrapedTags, err := listJavTagsForProviders(ctx, directoryIDs, closedSubdirs, visibleScrapedJavTagProviders(), int(jav.ProviderJavBus))
 	if err != nil {
 		return nil, err
 	}
-	userTags, err := listJavTagsForProviders(ctx, directoryIDs, []int{int(jav.ProviderUser)}, int(jav.ProviderUser))
+	userTags, err := listJavTagsForProviders(ctx, directoryIDs, closedSubdirs, []int{int(jav.ProviderUser)}, int(jav.ProviderUser))
 	if err != nil {
 		return nil, err
 	}
@@ -470,12 +473,12 @@ func ListJavTags(ctx context.Context, directoryIDs []int64) ([]JavTagCount, erro
 	return tags, nil
 }
 
-func listJavTagsForProviders(ctx context.Context, directoryIDs []int64, providers []int, outputProvider int) ([]JavTagCount, error) {
+func listJavTagsForProviders(ctx context.Context, directoryIDs []int64, closedSubdirs []ClosedSubdirectory, providers []int, outputProvider int) ([]JavTagCount, error) {
 	if len(providers) == 0 {
 		return nil, nil
 	}
 	var tags []JavTagCount
-	activeLocationSQL := activeLocationWhereSQL("vl", "d") + directoryFilterSQL("vl", directoryIDs)
+	activeLocationSQL := activeLocationWhereSQL("vl", "d") + directoryFilterSQL("vl", directoryIDs) + closedSubdirectoryFilterSQL("vl", closedSubdirs)
 	isUser := outputProvider == int(jav.ProviderUser)
 	tagMapJoin := "JOIN jav_tag_map jtm ON jtm.jav_tag_id = jt.id AND jtm.provider IN ?"
 	if isUser {
@@ -729,7 +732,7 @@ func replaceJavUserTagsTx(tx *gorm.DB, javIDs, tagIDs []int64) error {
 	return nil
 }
 
-func buildJavFilter(ctx context.Context, idolIDs []int64, tagIDs []int64, search, prefix string, directoryIDs []int64, studioID int64, seriesID int64, soloOnly bool, favoriteGroupID int64) *gorm.DB {
+func buildJavFilter(ctx context.Context, idolIDs []int64, tagIDs []int64, search, prefix string, directoryIDs []int64, closedSubdirs []ClosedSubdirectory, studioID int64, seriesID int64, soloOnly bool, favoriteGroupID int64) *gorm.DB {
 	q := common.DB.WithContext(ctx).Model(&models.Jav{})
 	visibleTagProviders := visibleJavTagProviders()
 	// Only include JAV entries that have at least one active file location.
@@ -740,6 +743,7 @@ func buildJavFilter(ctx context.Context, idolIDs []int64, tagIDs []int64, search
 		Where("vl.jav_id = jav.id").
 		Where(activeLocationWhereSQL("vl", "d"))
 	validLocation = applyDirectoryFilter(validLocation, "vl", directoryIDs)
+	validLocation = applyClosedSubdirectoryFilter(validLocation, "vl", closedSubdirs)
 	q = q.Where("EXISTS (?)", validLocation)
 	if search != "" {
 		like := fmt.Sprintf("%%%s%%", search)
@@ -865,7 +869,7 @@ func applyJavSeriesSearch(q *gorm.DB, search string) *gorm.DB {
 }
 
 // ListJavStudios returns studios ordered by visible work count descending.
-func ListJavStudios(ctx context.Context, search string, limit, offset int, directoryIDs []int64, favoriteGroupIDs ...int64) ([]JavStudioSummary, int64, error) {
+func ListJavStudios(ctx context.Context, search string, limit, offset int, directoryIDs []int64, closedSubdirs []ClosedSubdirectory, favoriteGroupIDs ...int64) ([]JavStudioSummary, int64, error) {
 	if limit <= 0 {
 		limit = 100
 	}
@@ -884,6 +888,7 @@ func ListJavStudios(ctx context.Context, search string, limit, offset int, direc
 		Joins("JOIN directory d ON d.id = vl.directory_id").
 		Where(activeLocationWhereSQL("vl", "d"))
 	countBase = applyDirectoryFilter(countBase, "vl", directoryIDs)
+	countBase = applyClosedSubdirectoryFilter(countBase, "vl", closedSubdirs)
 	countBase = applyJavStudioSearch(countBase, search)
 	if favoriteGroupID > 0 {
 		countBase = countBase.Joins("JOIN jav_favorite_map jfm_filter ON jfm_filter.entity_id = js.id AND jfm_filter.entity_type = ? AND jfm_filter.jav_favorite_group_id = ?", JavFavoriteEntityStudio, favoriteGroupID)
@@ -902,6 +907,7 @@ func ListJavStudios(ctx context.Context, search string, limit, offset int, direc
 		Joins("JOIN directory d ON d.id = vl.directory_id").
 		Where(activeLocationWhereSQL("vl", "d"))
 	base = applyDirectoryFilter(base, "vl", directoryIDs)
+	base = applyClosedSubdirectoryFilter(base, "vl", closedSubdirs)
 	base = applyJavStudioSearch(base, search)
 	if favoriteGroupID > 0 {
 		base = base.Joins("JOIN jav_favorite_map jfm_filter ON jfm_filter.entity_id = js.id AND jfm_filter.entity_type = ? AND jfm_filter.jav_favorite_group_id = ?", JavFavoriteEntityStudio, favoriteGroupID)
@@ -920,10 +926,10 @@ func ListJavStudios(ctx context.Context, search string, limit, offset int, direc
 		Scan(&items).Error; err != nil {
 		return nil, 0, fmt.Errorf("list jav studios: %w", err)
 	}
-	if err := attachJavStudioCodePrefixes(ctx, items, directoryIDs); err != nil {
+	if err := attachJavStudioCodePrefixes(ctx, items, directoryIDs, closedSubdirs); err != nil {
 		return nil, 0, err
 	}
-	if err := attachJavStudioSeries(ctx, items, directoryIDs); err != nil {
+	if err := attachJavStudioSeries(ctx, items, directoryIDs, closedSubdirs); err != nil {
 		return nil, 0, err
 	}
 	if err := attachJavStudioAliases(ctx, items); err != nil {
@@ -961,10 +967,10 @@ func GetJavStudioSummary(ctx context.Context, studioID int64, directoryIDs []int
 		return nil, gorm.ErrRecordNotFound
 	}
 	items := []JavStudioSummary{item}
-	if err := attachJavStudioCodePrefixes(ctx, items, directoryIDs); err != nil {
+	if err := attachJavStudioCodePrefixes(ctx, items, directoryIDs, nil); err != nil {
 		return nil, err
 	}
-	if err := attachJavStudioSeries(ctx, items, directoryIDs); err != nil {
+	if err := attachJavStudioSeries(ctx, items, directoryIDs, nil); err != nil {
 		return nil, err
 	}
 	if err := attachJavStudioAliases(ctx, items); err != nil {
@@ -1160,7 +1166,7 @@ func replaceJavStudioAliasesTx(tx *gorm.DB, studioID int64, aliases []string) er
 	return nil
 }
 
-func attachJavStudioCodePrefixes(ctx context.Context, items []JavStudioSummary, directoryIDs []int64) error {
+func attachJavStudioCodePrefixes(ctx context.Context, items []JavStudioSummary, directoryIDs []int64, closedSubdirs []ClosedSubdirectory) error {
 	if len(items) == 0 {
 		return nil
 	}
@@ -1194,6 +1200,7 @@ func attachJavStudioCodePrefixes(ctx context.Context, items []JavStudioSummary, 
 		Group("j.studio_id, " + prefixExpr).
 		Order("j.studio_id, prefix")
 	query = applyDirectoryFilter(query, "vl", directoryIDs)
+	query = applyClosedSubdirectoryFilter(query, "vl", closedSubdirs)
 	if err := query.Scan(&rows).Error; err != nil {
 		return fmt.Errorf("load jav studio code prefixes: %w", err)
 	}
@@ -1213,7 +1220,7 @@ func attachJavStudioCodePrefixes(ctx context.Context, items []JavStudioSummary, 
 	return nil
 }
 
-func attachJavStudioSeries(ctx context.Context, items []JavStudioSummary, directoryIDs []int64) error {
+func attachJavStudioSeries(ctx context.Context, items []JavStudioSummary, directoryIDs []int64, closedSubdirs []ClosedSubdirectory) error {
 	if len(items) == 0 {
 		return nil
 	}
@@ -1253,6 +1260,7 @@ func attachJavStudioSeries(ctx context.Context, items []JavStudioSummary, direct
 		Group("j.studio_id, js.id, js.name, js.studio_id, jst.name, favorite_counts.favorite_count").
 		Order("j.studio_id, work_count DESC, js.name ASC")
 	query = applyDirectoryFilter(query, "vl", directoryIDs)
+	query = applyClosedSubdirectoryFilter(query, "vl", closedSubdirs)
 	if err := query.Scan(&rows).Error; err != nil {
 		return fmt.Errorf("load jav studio series: %w", err)
 	}
@@ -1298,7 +1306,7 @@ func ListStudioCoverCodes(ctx context.Context, studioID int64, directoryIDs []in
 }
 
 // ListJavSeries returns series ordered by visible work count descending.
-func ListJavSeries(ctx context.Context, search string, limit, offset int, directoryIDs []int64, favoriteGroupIDs ...int64) ([]JavSeriesSummary, int64, error) {
+func ListJavSeries(ctx context.Context, search string, limit, offset int, directoryIDs []int64, closedSubdirs []ClosedSubdirectory, favoriteGroupIDs ...int64) ([]JavSeriesSummary, int64, error) {
 	if limit <= 0 {
 		limit = 100
 	}
@@ -1317,6 +1325,7 @@ func ListJavSeries(ctx context.Context, search string, limit, offset int, direct
 		Where("COALESCE(js.is_english, 0) = 0").
 		Where(activeLocationWhereSQL("vl", "d"))
 	countBase = applyDirectoryFilter(countBase, "vl", directoryIDs)
+	countBase = applyClosedSubdirectoryFilter(countBase, "vl", closedSubdirs)
 	countBase = applyJavSeriesSearch(countBase, search)
 	if favoriteGroupID > 0 {
 		countBase = countBase.Joins("JOIN jav_favorite_map jfm_filter ON jfm_filter.entity_id = js.id AND jfm_filter.entity_type = ? AND jfm_filter.jav_favorite_group_id = ?", JavFavoriteEntitySeries, favoriteGroupID)
@@ -1337,6 +1346,7 @@ func ListJavSeries(ctx context.Context, search string, limit, offset int, direct
 		Where("COALESCE(js.is_english, 0) = 0").
 		Where(activeLocationWhereSQL("vl", "d"))
 	base = applyDirectoryFilter(base, "vl", directoryIDs)
+	base = applyClosedSubdirectoryFilter(base, "vl", closedSubdirs)
 	base = applyJavSeriesSearch(base, search)
 	if favoriteGroupID > 0 {
 		base = base.Joins("JOIN jav_favorite_map jfm_filter ON jfm_filter.entity_id = js.id AND jfm_filter.entity_type = ? AND jfm_filter.jav_favorite_group_id = ?", JavFavoriteEntitySeries, favoriteGroupID)
@@ -1459,7 +1469,7 @@ func applyJavIdolSearch(q *gorm.DB, search string) *gorm.DB {
 	)
 }
 
-func buildVisibleSoloIdolCoverQuery(ctx context.Context, directoryIDs []int64) *gorm.DB {
+func buildVisibleSoloIdolCoverQuery(ctx context.Context, directoryIDs []int64, closedSubdirs []ClosedSubdirectory) *gorm.DB {
 	soloJavs := common.DB.WithContext(ctx).
 		Table("jav_idol_map jim_count").
 		Select("jim_count.jav_id").
@@ -1475,6 +1485,7 @@ func buildVisibleSoloIdolCoverQuery(ctx context.Context, directoryIDs []int64) *
 		Joins("JOIN directory d_solo ON d_solo.id = vl_solo.directory_id").
 		Where(activeLocationWhereSQL("vl_solo", "d_solo"))
 	query = applyDirectoryFilter(query, "vl_solo", directoryIDs)
+	query = applyClosedSubdirectoryFilter(query, "vl_solo", closedSubdirs)
 	return query.
 		Group("jim_solo.jav_idol_id")
 }
@@ -1502,7 +1513,7 @@ func GetJavIdolSummary(ctx context.Context, idolID int64, directoryIDs []int64) 
 		Table("jav_idol ji").
 		Select("ji.id, ji.name, ji.roman_name, ji.japanese_name, ji.chinese_name, ji.height_cm, ji.birth_date, ji.bust, ji.waist, ji.hips, ji.cup, COALESCE(idol_work_counts.work_count, 0) AS work_count, ji.cover_jav_id, COALESCE(NULLIF(cover_jav.code, ''), solo_idols.cover_code) AS cover_code, COALESCE(ji.cover_crop_left, 0.53) AS cover_crop_left, COALESCE(favorite_counts.favorite_count, 0) AS favorite_count").
 		Joins("LEFT JOIN (?) idol_work_counts ON idol_work_counts.jav_idol_id = ji.id", buildVisibleIdolWorkCountQuery(ctx, directoryIDs)).
-		Joins("LEFT JOIN (?) solo_idols ON solo_idols.jav_idol_id = ji.id", buildVisibleSoloIdolCoverQuery(ctx, directoryIDs)).
+		Joins("LEFT JOIN (?) solo_idols ON solo_idols.jav_idol_id = ji.id", buildVisibleSoloIdolCoverQuery(ctx, directoryIDs, nil)).
 		Joins("LEFT JOIN jav cover_jav ON cover_jav.id = ji.cover_jav_id").
 		Joins("LEFT JOIN (?) favorite_counts ON favorite_counts.jav_idol_id = ji.id", buildIdolFavoriteCountQuery(ctx)).
 		Where("ji.id = ?", idolID).
@@ -1578,7 +1589,7 @@ func ListJavIdolOptions(ctx context.Context, search string, limit, offset int) (
 }
 
 // ListJavIdols returns idols ordered by selected sort with pagination.
-func ListJavIdols(ctx context.Context, search, sort string, limit, offset int, directoryIDs []int64, favoriteGroupID int64) ([]JavIdolSummary, int64, error) {
+func ListJavIdols(ctx context.Context, search, sort string, limit, offset int, directoryIDs []int64, closedSubdirs []ClosedSubdirectory, favoriteGroupID int64) ([]JavIdolSummary, int64, error) {
 	if limit <= 0 {
 		limit = 100
 	}
@@ -1586,7 +1597,7 @@ func ListJavIdols(ctx context.Context, search, sort string, limit, offset int, d
 		offset = 0
 	}
 	sort = strings.ToLower(strings.TrimSpace(sort))
-	soloIdols := buildVisibleSoloIdolCoverQuery(ctx, directoryIDs)
+	soloIdols := buildVisibleSoloIdolCoverQuery(ctx, directoryIDs, closedSubdirs)
 
 	countBase := common.DB.WithContext(ctx).
 		Table("jav_idol ji").
@@ -1658,6 +1669,7 @@ func ListJavIdols(ctx context.Context, search, sort string, limit, offset int, d
 		base = base.Joins("JOIN jav_favorite_map jifm_filter ON jifm_filter.entity_id = ji.id AND jifm_filter.entity_type = ? AND jifm_filter.jav_favorite_group_id = ?", JavFavoriteEntityIdol, favoriteGroupID)
 	}
 	base = applyDirectoryFilter(base, "vl", directoryIDs)
+	base = applyClosedSubdirectoryFilter(base, "vl", closedSubdirs)
 	base = applyJavIdolSearch(base, search)
 	if err := base.
 		Joins("LEFT JOIN jav cover_jav ON cover_jav.id = ji.cover_jav_id").
@@ -2046,7 +2058,7 @@ func FindIdolSoloCode(ctx context.Context, idolID int64) (string, error) {
 // ListIdolsMissingProfile returns idols that have no profile fields populated.
 func ListIdolsMissingProfile(ctx context.Context) ([]models.JavIdol, error) {
 	var idols []models.JavIdol
-	soloIdols := buildVisibleSoloIdolCoverQuery(ctx, nil)
+	soloIdols := buildVisibleSoloIdolCoverQuery(ctx, nil, nil)
 	if err := common.DB.WithContext(ctx).
 		Joins("JOIN (?) solo_idols ON solo_idols.jav_idol_id = jav_idol.id", soloIdols).
 		Where(`

--- a/internal/db/jav_favorites.go
+++ b/internal/db/jav_favorites.go
@@ -129,7 +129,7 @@ func ListJavFavoriteGroups(ctx context.Context, entityType string, directoryIDs 
 			Select("jfg.id, jfg.entity_type, jfg.name, jfg.sort_order, COUNT(DISTINCT CASE WHEN solo_idols.cover_code IS NOT NULL THEN jfm.entity_id END) AS count").
 			Joins("LEFT JOIN jav_favorite_map jfm ON jfm.jav_favorite_group_id = jfg.id AND jfm.entity_type = ?", entityType).
 			Joins("LEFT JOIN jav_idol ji ON ji.id = jfm.entity_id").
-			Joins("LEFT JOIN (?) solo_idols ON solo_idols.jav_idol_id = jfm.entity_id", buildVisibleSoloIdolCoverQuery(ctx, directoryIDs))
+			Joins("LEFT JOIN (?) solo_idols ON solo_idols.jav_idol_id = jfm.entity_id", buildVisibleSoloIdolCoverQuery(ctx, directoryIDs, nil))
 	case JavFavoriteEntityJav:
 		query = query.
 			Select("jfg.id, jfg.entity_type, jfg.name, jfg.sort_order, COUNT(DISTINCT CASE WHEN j.id IS NOT NULL AND vl.id IS NOT NULL AND d.id IS NOT NULL AND "+activeLocationWhereSQL("vl", "d")+directoryFilterSQL("vl", directoryIDs)+" THEN j.id END) AS count").
@@ -439,7 +439,7 @@ func ListJavFavoriteGroupItems(ctx context.Context, entityType string, groupID i
 		query = query.
 			Select("'idol' AS entity_type, ji.id, ji.name, ji.roman_name, ji.japanese_name, ji.chinese_name, COUNT(DISTINCT j.id) AS work_count, COALESCE(NULLIF(cover_jav.code, ''), solo_idols.cover_code) AS sample_code").
 			Joins("JOIN jav_idol ji ON ji.id = jfm.entity_id").
-			Joins("JOIN (?) solo_idols ON solo_idols.jav_idol_id = ji.id", buildVisibleSoloIdolCoverQuery(ctx, directoryIDs)).
+			Joins("JOIN (?) solo_idols ON solo_idols.jav_idol_id = ji.id", buildVisibleSoloIdolCoverQuery(ctx, directoryIDs, nil)).
 			Joins("LEFT JOIN jav cover_jav ON cover_jav.id = ji.cover_jav_id").
 			Joins("JOIN jav_idol_map jim ON jim.jav_idol_id = ji.id").
 			Joins("JOIN jav j ON j.id = jim.jav_id").

--- a/internal/db/jav_test.go
+++ b/internal/db/jav_test.go
@@ -172,7 +172,7 @@ func TestListJavIdolsOnlyIncludesIdolsWithVisibleSoloWorks(t *testing.T) {
 		t.Fatalf("mark unavailable video location deleted: %v", err)
 	}
 
-	items, total, err := ListJavIdols(ctx, "", "", 20, 0, nil, 0)
+	items, total, err := ListJavIdols(ctx, "", "", 20, 0, nil, nil, 0)
 	if err != nil {
 		t.Fatalf("ListJavIdols: %v", err)
 	}
@@ -286,7 +286,7 @@ func TestListJavPrefixesAndSearchByPrefix(t *testing.T) {
 		t.Fatalf("unexpected unknown-studio prefix: %#v", prefixes[2])
 	}
 
-	items, total, err := SearchJavWithPrefix(ctx, nil, nil, "", "pfx", "code", 20, 0, nil, nil)
+	items, total, err := SearchJavWithPrefix(ctx, nil, nil, "", "pfx", "code", 20, 0, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("SearchJavWithPrefix: %v", err)
 	}
@@ -297,7 +297,7 @@ func TestListJavPrefixesAndSearchByPrefix(t *testing.T) {
 		t.Fatalf("unexpected pfx codes: %#v", []string{items[0].Code, items[1].Code, items[2].Code, items[3].Code})
 	}
 
-	items, total, err = SearchJavWithPrefix(ctx, nil, nil, "", "pfx", "code", 20, 0, nil, nil, 0)
+	items, total, err = SearchJavWithPrefix(ctx, nil, nil, "", "pfx", "code", 20, 0, nil, nil, nil, 0)
 	if err != nil {
 		t.Fatalf("SearchJavWithPrefix unknown studio: %v", err)
 	}
@@ -890,7 +890,7 @@ func TestListJavStudiosAndSearchByStudio(t *testing.T) {
 	}
 	createVideoLocationsForVideos(t, db, videos...)
 
-	studios, total, err := ListJavStudios(ctx, "", 20, 0, nil)
+	studios, total, err := ListJavStudios(ctx, "", 20, 0, nil, nil)
 	if err != nil {
 		t.Fatalf("ListJavStudios: %v", err)
 	}
@@ -979,7 +979,7 @@ func TestListJavSeriesAndSearchBySeries(t *testing.T) {
 	}
 	createVideoLocationsForVideos(t, db, videos...)
 
-	series, total, err := ListJavSeries(ctx, "", 20, 0, nil)
+	series, total, err := ListJavSeries(ctx, "", 20, 0, nil, nil)
 	if err != nil {
 		t.Fatalf("ListJavSeries: %v", err)
 	}
@@ -1337,7 +1337,7 @@ func TestCreatedUserJavTagAppearsWithZeroCount(t *testing.T) {
 		t.Fatalf("CreateJavTag: %v", err)
 	}
 
-	tags, err := ListJavTags(ctx, nil)
+	tags, err := ListJavTags(ctx, nil, nil)
 	if err != nil {
 		t.Fatalf("ListJavTags: %v", err)
 	}
@@ -1444,7 +1444,7 @@ func TestJavTagsFilterOutEnglishProviders(t *testing.T) {
 		t.Fatalf("create tag maps: %v", err)
 	}
 
-	zhTags, err := ListJavTags(ctx, nil)
+	zhTags, err := ListJavTags(ctx, nil, nil)
 	if err != nil {
 		t.Fatalf("ListJavTags zh: %v", err)
 	}
@@ -2025,7 +2025,7 @@ func TestJavBindingUsesVideoLocationsAndCountsTagWorks(t *testing.T) {
 		t.Fatal("expected location-backed videos to keep the original video id")
 	}
 
-	tags, err := ListJavTags(ctx, nil)
+	tags, err := ListJavTags(ctx, nil, nil)
 	if err != nil {
 		t.Fatalf("ListJavTags: %v", err)
 	}
@@ -2037,7 +2037,7 @@ func TestJavBindingUsesVideoLocationsAndCountsTagWorks(t *testing.T) {
 		t.Fatalf("tag count = %d, want 1", tagCounts[tag.Name])
 	}
 
-	idols, _, err := ListJavIdols(ctx, "", "work", 20, 0, nil, 0)
+	idols, _, err := ListJavIdols(ctx, "", "work", 20, 0, nil, nil, 0)
 	if err != nil {
 		t.Fatalf("ListJavIdols: %v", err)
 	}
@@ -2391,7 +2391,7 @@ func TestListJavIdolsSortByAgeDirections(t *testing.T) {
 	}
 	createVideoLocationsForVideos(t, db, videos...)
 
-	items, total, err := ListJavIdols(ctx, "", "birth", 20, 0, nil, 0)
+	items, total, err := ListJavIdols(ctx, "", "birth", 20, 0, nil, nil, 0)
 	if err != nil {
 		t.Fatalf("ListJavIdols birth: %v", err)
 	}
@@ -2402,7 +2402,7 @@ func TestListJavIdolsSortByAgeDirections(t *testing.T) {
 		t.Fatalf("unexpected birth first idol: got %d want %d", items[0].ID, youngIdol.ID)
 	}
 
-	items, total, err = ListJavIdols(ctx, "", "birth_asc", 20, 0, nil, 0)
+	items, total, err = ListJavIdols(ctx, "", "birth_asc", 20, 0, nil, nil, 0)
 	if err != nil {
 		t.Fatalf("ListJavIdols birth_asc: %v", err)
 	}
@@ -2472,7 +2472,7 @@ func TestListJavIdolsSortByRecentDirections(t *testing.T) {
 	}
 	createVideoLocationsForVideos(t, db, videos...)
 
-	items, total, err := ListJavIdols(ctx, "", "recent", 20, 0, nil, 0)
+	items, total, err := ListJavIdols(ctx, "", "recent", 20, 0, nil, nil, 0)
 	if err != nil {
 		t.Fatalf("ListJavIdols recent: %v", err)
 	}
@@ -2483,7 +2483,7 @@ func TestListJavIdolsSortByRecentDirections(t *testing.T) {
 		t.Fatalf("unexpected recent first idol: got %d want %d", items[0].ID, newIdol.ID)
 	}
 
-	items, total, err = ListJavIdols(ctx, "", "recent_asc", 20, 0, nil, 0)
+	items, total, err = ListJavIdols(ctx, "", "recent_asc", 20, 0, nil, nil, 0)
 	if err != nil {
 		t.Fatalf("ListJavIdols recent_asc: %v", err)
 	}
@@ -2539,7 +2539,7 @@ func TestUpdateJavStudioProfileUpdatesAliasesAndResolvesScrapedName(t *testing.T
 		t.Fatalf("studio aliases = %#v, want Alias Studio", updated.Aliases)
 	}
 
-	items, total, err := ListJavStudios(ctx, "Alias Studio", 20, 0, nil)
+	items, total, err := ListJavStudios(ctx, "Alias Studio", 20, 0, nil, nil)
 	if err != nil {
 		t.Fatalf("ListJavStudios by alias: %v", err)
 	}

--- a/internal/db/migrations/202608030001_add_video_format.go
+++ b/internal/db/migrations/202608030001_add_video_format.go
@@ -1,0 +1,16 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddNamedMigrationContext("202608030001_add_video_format.go", addVideoFormat, irreversibleMigration)
+}
+
+func addVideoFormat(ctx context.Context, tx *sql.Tx) error {
+	return addColumnIfMissing(ctx, tx, "video", "format", "text")
+}

--- a/internal/db/subdirectories_test.go
+++ b/internal/db/subdirectories_test.go
@@ -1,0 +1,415 @@
+package db
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"javboss/internal/models"
+)
+
+func TestListDirectorySubdirectories(t *testing.T) {
+	gdb := openTestDB(t)
+	ctx := context.Background()
+	now := time.Unix(1710000000, 0).UTC()
+
+	dir := models.Directory{Path: "/media/subdir-root"}
+	if err := gdb.Create(&dir).Error; err != nil {
+		t.Fatalf("create directory: %v", err)
+	}
+	// Videos: root file, two under "JAV", one under "IDOL", one deleted under "HIDDEN".
+	files := []string{
+		"root.mp4",
+		"JAV/IPX-001.mp4",
+		"JAV/IPX-002.mp4",
+		"IDOL/name-001.mp4",
+		"HIDDEN/secret.mp4",
+	}
+	locations := make([]models.VideoLocation, 0, len(files))
+	for i, rel := range files {
+		video := models.Video{Fingerprint: "subdir-video-" + string(rune('a'+i))}
+		if err := gdb.Create(&video).Error; err != nil {
+			t.Fatalf("create video: %v", err)
+		}
+		loc, err := UpsertVideoLocation(ctx, video.ID, dir.ID, rel, now)
+		if err != nil {
+			t.Fatalf("upsert location %s: %v", rel, err)
+		}
+		locations = append(locations, *loc)
+	}
+	if err := gdb.Model(&models.VideoLocation{}).
+		Where("id = ?", locations[4].ID).
+		Update("is_delete", true).Error; err != nil {
+		t.Fatalf("hide location: %v", err)
+	}
+
+	got, err := ListDirectorySubdirectories(ctx, dir.ID)
+	if err != nil {
+		t.Fatalf("list subdirectories: %v", err)
+	}
+	if got.RootVideoCount != 1 {
+		t.Fatalf("root video count = %d, want 1", got.RootVideoCount)
+	}
+	if len(got.Subdirectories) != 2 {
+		t.Fatalf("subdirectory count = %d, want 2 (%#v)", len(got.Subdirectories), got.Subdirectories)
+	}
+	if got.Subdirectories[0].Name != "JAV" || got.Subdirectories[0].VideoCount != 2 {
+		t.Fatalf("first subdirectory = %+v, want JAV with 2 videos", got.Subdirectories[0])
+	}
+	if got.Subdirectories[1].Name != "IDOL" || got.Subdirectories[1].VideoCount != 1 {
+		t.Fatalf("second subdirectory = %+v, want IDOL with 1 video", got.Subdirectories[1])
+	}
+}
+
+func TestListDirectorySubdirectoriesNoRootFiles(t *testing.T) {
+	gdb := openTestDB(t)
+	ctx := context.Background()
+	now := time.Unix(1710000000, 0).UTC()
+
+	dir := models.Directory{Path: "/media/subdir-no-root"}
+	if err := gdb.Create(&dir).Error; err != nil {
+		t.Fatalf("create directory: %v", err)
+	}
+	for i, rel := range []string{"A/one.mp4", "A/two.mp4", "B/three.mp4"} {
+		video := models.Video{Fingerprint: "subdir-no-root-" + string(rune('a'+i))}
+		if err := gdb.Create(&video).Error; err != nil {
+			t.Fatalf("create video: %v", err)
+		}
+		if _, err := UpsertVideoLocation(ctx, video.ID, dir.ID, rel, now); err != nil {
+			t.Fatalf("upsert location %s: %v", rel, err)
+		}
+	}
+
+	got, err := ListDirectorySubdirectories(ctx, dir.ID)
+	if err != nil {
+		t.Fatalf("list subdirectories: %v", err)
+	}
+	if got.RootVideoCount != 0 {
+		t.Fatalf("root video count = %d, want 0", got.RootVideoCount)
+	}
+	if len(got.Subdirectories) != 2 {
+		t.Fatalf("subdirectory count = %d, want 2 (%#v)", len(got.Subdirectories), got.Subdirectories)
+	}
+}
+
+func TestListDirectorySubdirectoriesNestedTree(t *testing.T) {
+	gdb := openTestDB(t)
+	ctx := context.Background()
+	now := time.Unix(1710000000, 0).UTC()
+
+	dir := models.Directory{Path: "/media/subdir-tree"}
+	if err := gdb.Create(&dir).Error; err != nil {
+		t.Fatalf("create directory: %v", err)
+	}
+	entries := []string{
+		"root.mp4",
+		"JAV/a.mp4",
+		"JAV/ABC/deep1.mp4",
+		"JAV/ABC/deep2.mp4",
+		"JAV/XYZ/deep3.mp4",
+		"IDOL/b.mp4",
+	}
+	for i, rel := range entries {
+		video := models.Video{Fingerprint: "subdir-tree-" + string(rune('a'+i))}
+		if err := gdb.Create(&video).Error; err != nil {
+			t.Fatalf("create video: %v", err)
+		}
+		if _, err := UpsertVideoLocation(ctx, video.ID, dir.ID, rel, now); err != nil {
+		t.Fatalf("upsert location %s: %v", rel, err)
+		}
+	}
+
+	got, err := ListDirectorySubdirectories(ctx, dir.ID)
+	if err != nil {
+		t.Fatalf("list subdirectories: %v", err)
+	}
+	if got.RootVideoCount != 1 {
+		t.Fatalf("root video count = %d, want 1", got.RootVideoCount)
+	}
+	if len(got.Subdirectories) != 2 {
+		t.Fatalf("top-level subdirectories = %d, want 2 (%#v)", len(got.Subdirectories), got.Subdirectories)
+	}
+	jav := got.Subdirectories[0]
+	if jav.Name != "JAV" || jav.Path != "JAV" || jav.DirectVideoCount != 1 || jav.VideoCount != 4 {
+		t.Fatalf("JAV node = %+v, want direct 1 total 4", jav)
+	}
+	if len(jav.Subdirectories) != 2 {
+		t.Fatalf("JAV children = %d, want 2 (%#v)", len(jav.Subdirectories), jav.Subdirectories)
+	}
+	abc := jav.Subdirectories[0]
+	if abc.Name != "ABC" || abc.Path != "JAV/ABC" || abc.DirectVideoCount != 2 || abc.VideoCount != 2 {
+		t.Fatalf("ABC node = %+v, want direct 2 total 2", abc)
+	}
+	if len(abc.Subdirectories) != 0 {
+		t.Fatalf("ABC children = %d, want 0", len(abc.Subdirectories))
+	}
+	xyz := jav.Subdirectories[1]
+	if xyz.Name != "XYZ" || xyz.Path != "JAV/XYZ" || xyz.VideoCount != 1 {
+		t.Fatalf("XYZ node = %+v, want total 1", xyz)
+	}
+}
+
+func TestClosedSubdirectoryFilterNested(t *testing.T) {
+	gdb := openTestDB(t)
+	ctx := context.Background()
+	now := time.Unix(1710000000, 0).UTC()
+
+	dir := models.Directory{Path: "/media/closed-nested"}
+	if err := gdb.Create(&dir).Error; err != nil {
+		t.Fatalf("create directory: %v", err)
+	}
+	entries := []string{
+		"JAV/direct.mp4",
+		"JAV/ABC/deep1.mp4",
+		"JAV/ABC/deep2.mp4",
+		"JAV/XYZ/deep3.mp4",
+		"IDOL/other.mp4",
+	}
+	for i, rel := range entries {
+		video := models.Video{Fingerprint: "closed-nested-" + string(rune('a'+i))}
+		if err := gdb.Create(&video).Error; err != nil {
+			t.Fatalf("create video: %v", err)
+		}
+		if _, err := UpsertVideoLocation(ctx, video.ID, dir.ID, rel, now); err != nil {
+		t.Fatalf("upsert location %s: %v", rel, err)
+		}
+	}
+
+	// Closing only the nested JAV/ABC hides that subtree but keeps JAV direct files.
+	closed := []ClosedSubdirectory{{DirectoryID: dir.ID, Name: "JAV/ABC"}}
+	items, err := ListVideos(ctx, 50, 0, nil, "", "recent", nil, []int64{dir.ID}, closed)
+	if err != nil {
+		t.Fatalf("list videos with nested closed subdir: %v", err)
+	}
+	if len(items) != 3 {
+		t.Fatalf("nested filter count = %d, want 3 (%#v)", len(items), items)
+	}
+	for _, item := range items {
+		if item.Path == "JAV/ABC/deep1.mp4" || item.Path == "JAV/ABC/deep2.mp4" {
+			t.Fatalf("nested closed subdirectory video still visible: %s", item.Path)
+		}
+	}
+
+	// Closing the parent JAV hides the whole subtree including JAV/ABC.
+	closedParent := []ClosedSubdirectory{{DirectoryID: dir.ID, Name: "JAV"}}
+	parentItems, err := ListVideos(ctx, 50, 0, nil, "", "recent", nil, []int64{dir.ID}, closedParent)
+	if err != nil {
+		t.Fatalf("list videos with parent closed subdir: %v", err)
+	}
+	if len(parentItems) != 1 || parentItems[0].Path != "IDOL/other.mp4" {
+		t.Fatalf("parent filter result = %#v, want only IDOL/other.mp4", parentItems)
+	}
+}
+
+func TestClosedSubdirectoryFilterVideos(t *testing.T) {
+	gdb := openTestDB(t)
+	ctx := context.Background()
+	now := time.Unix(1710000000, 0).UTC()
+
+	dirA := models.Directory{Path: "/media/closed-a"}
+	dirB := models.Directory{Path: "/media/closed-b"}
+	if err := gdb.Create(&dirA).Error; err != nil {
+		t.Fatalf("create directory A: %v", err)
+	}
+	if err := gdb.Create(&dirB).Error; err != nil {
+		t.Fatalf("create directory B: %v", err)
+	}
+	// dirA: root file + JAV subdir; dirB: PRED subdir.
+	entries := []struct {
+		dir  models.Directory
+		path string
+	}{
+		{dirA, "root.mp4"},
+		{dirA, "JAV/IPX-001.mp4"},
+		{dirA, "JAV/IPX-002.mp4"},
+		{dirA, "IDOL/name-001.mp4"},
+		{dirB, "PRED/PRED-001.mp4"},
+	}
+	for i, entry := range entries {
+		video := models.Video{Fingerprint: "closed-filter-" + string(rune('a'+i))}
+		if err := gdb.Create(&video).Error; err != nil {
+			t.Fatalf("create video: %v", err)
+		}
+		if _, err := UpsertVideoLocation(ctx, video.ID, entry.dir.ID, entry.path, now); err != nil {
+			t.Fatalf("upsert location %s: %v", entry.path, err)
+		}
+	}
+
+	// No closed subdirs: everything in dirA is visible.
+	all, err := ListVideos(ctx, 50, 0, nil, "", "recent", nil, []int64{dirA.ID}, nil)
+	if err != nil {
+		t.Fatalf("list videos without filter: %v", err)
+	}
+	if len(all) != 4 {
+		t.Fatalf("unfiltered count = %d, want 4", len(all))
+	}
+
+	// Close JAV under dirA: root + IDOL remain, JAV is hidden.
+	closed := []ClosedSubdirectory{{DirectoryID: dirA.ID, Name: "JAV"}}
+	filtered, err := ListVideos(ctx, 50, 0, nil, "", "recent", nil, []int64{dirA.ID}, closed)
+	if err != nil {
+		t.Fatalf("list videos with closed subdir: %v", err)
+	}
+	if len(filtered) != 2 {
+		t.Fatalf("filtered count = %d, want 2 (%#v)", len(filtered), filtered)
+	}
+	for _, item := range filtered {
+		if item.Path == "JAV/IPX-001.mp4" || item.Path == "JAV/IPX-002.mp4" {
+			t.Fatalf("closed subdirectory video still visible: %s", item.Path)
+		}
+	}
+	count, err := CountVideos(ctx, nil, "", []int64{dirA.ID}, closed)
+	if err != nil {
+		t.Fatalf("count videos with closed subdir: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("filtered count total = %d, want 2", count)
+	}
+
+	// Closing JAV in dirA must not affect dirB.
+	dirBItems, err := ListVideos(ctx, 50, 0, nil, "", "recent", nil, []int64{dirA.ID, dirB.ID}, closed)
+	if err != nil {
+		t.Fatalf("list videos across directories: %v", err)
+	}
+	if len(dirBItems) != 3 {
+		t.Fatalf("cross-directory count = %d, want 3 (dirA root+IDOL, dirB PRED)", len(dirBItems))
+	}
+}
+
+func TestClosedSubdirectoryFilterJav(t *testing.T) {
+	gdb := openTestDB(t)
+	ctx := context.Background()
+	now := time.Unix(1710000000, 0).UTC()
+
+	dir := models.Directory{Path: "/media/closed-jav"}
+	if err := gdb.Create(&dir).Error; err != nil {
+		t.Fatalf("create directory: %v", err)
+	}
+	javA := models.Jav{Code: "CLOSED-001", Title: "Closed A"}
+	javB := models.Jav{Code: "CLOSED-002", Title: "Closed B"}
+	if err := gdb.Create(&javA).Error; err != nil {
+		t.Fatalf("create jav A: %v", err)
+	}
+	if err := gdb.Create(&javB).Error; err != nil {
+		t.Fatalf("create jav B: %v", err)
+	}
+	entries := []struct {
+		jav  models.Jav
+		path string
+	}{
+		{javA, "KEEP/CLOSED-001.mp4"},
+		{javB, "HIDE/CLOSED-002.mp4"},
+	}
+	for i, entry := range entries {
+		video := models.Video{Fingerprint: "closed-jav-" + string(rune('a'+i))}
+		if err := gdb.Create(&video).Error; err != nil {
+			t.Fatalf("create video: %v", err)
+		}
+		loc, err := UpsertVideoLocation(ctx, video.ID, dir.ID, entry.path, now)
+		if err != nil {
+			t.Fatalf("upsert location %s: %v", entry.path, err)
+		}
+		if err := gdb.Model(&models.VideoLocation{}).
+			Where("id = ?", loc.ID).
+			Update("jav_id", entry.jav.ID).Error; err != nil {
+			t.Fatalf("link jav: %v", err)
+		}
+	}
+
+	closed := []ClosedSubdirectory{{DirectoryID: dir.ID, Name: "HIDE"}}
+	items, total, err := SearchJavWithPrefix(ctx, nil, nil, "", "", "recent", 50, 0, nil, []int64{dir.ID}, closed)
+	if err != nil {
+		t.Fatalf("search jav with closed subdir: %v", err)
+	}
+	if total != 1 || len(items) != 1 || items[0].ID != javA.ID {
+		t.Fatalf("jav filter = total %d items %#v, want only CLOSED-001", total, items)
+	}
+	if len(items[0].Videos) != 1 || items[0].Videos[0].Path != "KEEP/CLOSED-001.mp4" {
+		t.Fatalf("attached videos = %#v, want only KEEP/CLOSED-001.mp4", items[0].Videos)
+	}
+}
+
+func TestClosedSubdirectoryFilterTags(t *testing.T) {
+	gdb := openTestDB(t)
+	ctx := context.Background()
+	now := time.Unix(1710000000, 0).UTC()
+
+	dir := models.Directory{Path: "/media/closed-tags"}
+	if err := gdb.Create(&dir).Error; err != nil {
+		t.Fatalf("create directory: %v", err)
+	}
+	tag := models.Tag{Name: "closed-tag"}
+	if err := gdb.Create(&tag).Error; err != nil {
+		t.Fatalf("create tag: %v", err)
+	}
+	entries := []string{"VISIBLE/one.mp4", "HIDDEN/two.mp4"}
+	for i, rel := range entries {
+		video := models.Video{Fingerprint: "closed-tag-" + string(rune('a'+i))}
+		if err := gdb.Create(&video).Error; err != nil {
+			t.Fatalf("create video: %v", err)
+		}
+		loc, err := UpsertVideoLocation(ctx, video.ID, dir.ID, rel, now)
+		if err != nil {
+			t.Fatalf("upsert location %s: %v", rel, err)
+		}
+		if err := gdb.Model(&models.VideoTag{}).Create(&models.VideoTag{VideoID: video.ID, TagID: tag.ID}).Error; err != nil {
+			t.Fatalf("tag video: %v", err)
+		}
+		_ = loc
+	}
+
+	closed := []ClosedSubdirectory{{DirectoryID: dir.ID, Name: "HIDDEN"}}
+	tags, err := ListTags(ctx, []int64{dir.ID}, closed)
+	if err != nil {
+		t.Fatalf("list tags with closed subdir: %v", err)
+	}
+	if len(tags) != 1 || tags[0].Count != 1 {
+		t.Fatalf("tag counts = %#v, want 1 tag with count 1", tags)
+	}
+}
+
+func TestClosedSubdirectoryFilterSpecialNames(t *testing.T) {
+	gdb := openTestDB(t)
+	ctx := context.Background()
+	now := time.Unix(1710000000, 0).UTC()
+
+	dir := models.Directory{Path: "/media/closed-special"}
+	if err := gdb.Create(&dir).Error; err != nil {
+		t.Fatalf("create directory: %v", err)
+	}
+	// Subdirectory names containing LIKE wildcards, slashes and quotes.
+	entries := []string{
+		"50%_off/a.mp4",
+		"50%_off/b.mp4",
+		"it's/c.mp4",
+		"plain/d.mp4",
+	}
+	for i, rel := range entries {
+		video := models.Video{Fingerprint: "closed-special-" + string(rune('a'+i))}
+		if err := gdb.Create(&video).Error; err != nil {
+			t.Fatalf("create video: %v", err)
+		}
+		if _, err := UpsertVideoLocation(ctx, video.ID, dir.ID, rel, now); err != nil {
+			t.Fatalf("upsert location %s: %v", rel, err)
+		}
+	}
+
+	closed := []ClosedSubdirectory{
+		{DirectoryID: dir.ID, Name: "50%_off"},
+		{DirectoryID: dir.ID, Name: "it's"},
+	}
+	items, err := ListVideos(ctx, 50, 0, nil, "", "recent", nil, []int64{dir.ID}, closed)
+	if err != nil {
+		t.Fatalf("list videos with special names: %v", err)
+	}
+	if len(items) != 1 || items[0].Path != "plain/d.mp4" {
+		t.Fatalf("special-name filter result = %#v, want only plain/d.mp4", items)
+	}
+
+	// The inline SQL variant (used by tag counts) must behave the same.
+	tags, err := ListTags(ctx, []int64{dir.ID}, closed)
+	if err != nil {
+		t.Fatalf("list tags with special names: %v", err)
+	}
+	_ = tags
+}

--- a/internal/db/tags.go
+++ b/internal/db/tags.go
@@ -70,7 +70,7 @@ func RenameTag(ctx context.Context, id int64, newName string) error {
 
 // ListTags returns all tags ordered by name with attached active location counts.
 // By default it includes locations already associated with JAV metadata.
-func ListTags(ctx context.Context, directoryIDs []int64, hideJav ...bool) ([]TagCount, error) {
+func ListTags(ctx context.Context, directoryIDs []int64, closedSubdirs []ClosedSubdirectory, hideJav ...bool) ([]TagCount, error) {
 	var tags []TagCount
 	hideRecognizedJav := false
 	if len(hideJav) > 0 {
@@ -80,6 +80,7 @@ func ListTags(ctx context.Context, directoryIDs []int64, hideJav ...bool) ([]Tag
 	if hideRecognizedJav {
 		countWhere += " AND vl.jav_id IS NULL"
 	}
+	countWhere += closedSubdirectoryFilterSQL("vl", closedSubdirs)
 	query := common.DB.WithContext(ctx).
 		Table("tag t").
 		Select("t.id, t.name, COUNT(DISTINCT CASE WHEN " + countWhere + " THEN vl.id END) AS count").

--- a/internal/db/video_locations.go
+++ b/internal/db/video_locations.go
@@ -280,6 +280,84 @@ func activeLocationWhereSQL(locationAlias, directoryAlias string) string {
 	)
 }
 
+// ClosedSubdirectory represents a first-level subdirectory whose content is hidden
+// inside an otherwise enabled root directory. Name is the first path segment of
+// video_location.relative_path (forward slashes).
+type ClosedSubdirectory struct {
+	DirectoryID int64
+	Name        string
+}
+
+func escapeLikeLiteral(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `%`, `\%`)
+	s = strings.ReplaceAll(s, `_`, `\_`)
+	return s
+}
+
+// closedSubdirectoryConditionSQL builds one condition matching a closed subdirectory:
+// the location belongs to the directory and its relative path is exactly the
+// subdirectory name or starts with "name/".
+func closedSubdirectoryConditionSQL(locationAlias, name string) string {
+	return fmt.Sprintf(
+		"(%s.directory_id = ? AND (%s.relative_path = ? OR %s.relative_path LIKE ? ESCAPE '\\'))",
+		locationAlias, locationAlias, locationAlias,
+	)
+}
+
+// applyClosedSubdirectoryFilter hides locations under the given closed subdirectories.
+// It is meant to be combined (AND) with applyDirectoryFilter.
+func applyClosedSubdirectoryFilter(q *gorm.DB, locationAlias string, closed []ClosedSubdirectory) *gorm.DB {
+	if len(closed) == 0 {
+		return q
+	}
+	locationAlias = strings.TrimSpace(locationAlias)
+	if locationAlias == "" {
+		locationAlias = "video_location"
+	}
+	conditions := make([]string, 0, len(closed))
+	args := make([]any, 0, len(closed)*3)
+	for _, item := range closed {
+		if item.DirectoryID <= 0 || strings.TrimSpace(item.Name) == "" {
+			continue
+		}
+		conditions = append(conditions, closedSubdirectoryConditionSQL(locationAlias, item.Name))
+		args = append(args, item.DirectoryID, item.Name, escapeLikeLiteral(item.Name)+"/%")
+	}
+	if len(conditions) == 0 {
+		return q
+	}
+	return q.Where("NOT ("+strings.Join(conditions, " OR ")+")", args...)
+}
+
+// closedSubdirectoryFilterSQL returns an inline " AND NOT (...)" fragment for use in
+// concatenated SQL expressions (e.g. ORDER BY subqueries or CASE WHEN counts).
+// Values are inlined so names must be single-quote escaped.
+func closedSubdirectoryFilterSQL(locationAlias string, closed []ClosedSubdirectory) string {
+	if len(closed) == 0 {
+		return ""
+	}
+	locationAlias = strings.TrimSpace(locationAlias)
+	if locationAlias == "" {
+		locationAlias = "video_location"
+	}
+	conditions := make([]string, 0, len(closed))
+	for _, item := range closed {
+		if item.DirectoryID <= 0 || strings.TrimSpace(item.Name) == "" {
+			continue
+		}
+		escaped := strings.ReplaceAll(item.Name, "'", "''")
+		conditions = append(conditions, fmt.Sprintf(
+			"(%s.directory_id = %d AND (%s.relative_path = '%s' OR %s.relative_path LIKE '%s/%%' ESCAPE '\\'))",
+			locationAlias, item.DirectoryID, locationAlias, escaped, locationAlias, escapeLikeLiteral(escaped),
+		))
+	}
+	if len(conditions) == 0 {
+		return ""
+	}
+	return " AND NOT (" + strings.Join(conditions, " OR ") + ")"
+}
+
 func applyDirectoryFilter(q *gorm.DB, locationAlias string, directoryIDs []int64) *gorm.DB {
 	if hasZeroID(directoryIDs) {
 		return q.Where("1 = 0")

--- a/internal/db/videos.go
+++ b/internal/db/videos.go
@@ -17,7 +17,7 @@ import (
 
 // ListVideos returns paginated active video locations as video-like rows.
 // By default it includes locations already associated with JAV metadata.
-func ListVideos(ctx context.Context, limit, offset int, tagNames []string, search, sort string, seed *int64, directoryIDs []int64, hideJav ...bool) ([]models.Video, error) {
+func ListVideos(ctx context.Context, limit, offset int, tagNames []string, search, sort string, seed *int64, directoryIDs []int64, closedSubdirs []ClosedSubdirectory, hideJav ...bool) ([]models.Video, error) {
 	if limit <= 0 {
 		limit = 100
 	}
@@ -78,6 +78,7 @@ func ListVideos(ctx context.Context, limit, offset int, tagNames []string, searc
 		query = query.Where("video_location.jav_id IS NULL")
 	}
 	query = applyDirectoryFilter(query, "video_location", directoryIDs)
+	query = applyClosedSubdirectoryFilter(query, "video_location", closedSubdirs)
 	if useExpr {
 		query = query.Order(clause.OrderBy{Expression: orderExpr})
 	} else {
@@ -119,7 +120,7 @@ func ListVideos(ctx context.Context, limit, offset int, tagNames []string, searc
 
 // CountVideos returns the total number of active locations that match optional filters.
 // By default it includes locations already associated with JAV metadata.
-func CountVideos(ctx context.Context, tagNames []string, search string, directoryIDs []int64, hideJav ...bool) (int64, error) {
+func CountVideos(ctx context.Context, tagNames []string, search string, directoryIDs []int64, closedSubdirs []ClosedSubdirectory, hideJav ...bool) (int64, error) {
 	cleanedTags := normalizeTagNames(tagNames)
 	cleanedSearch := strings.TrimSpace(search)
 	hideRecognizedJav := false
@@ -142,6 +143,7 @@ func CountVideos(ctx context.Context, tagNames []string, search string, director
 			base = base.Where("video_location.jav_id IS NULL")
 		}
 		base = applyDirectoryFilter(base, "video_location", directoryIDs)
+		base = applyClosedSubdirectoryFilter(base, "video_location", closedSubdirs)
 		if like != "" {
 			base = base.Where("video_location.filename LIKE ? COLLATE NOCASE", like)
 		}
@@ -165,6 +167,7 @@ func CountVideos(ctx context.Context, tagNames []string, search string, director
 		sub = sub.Where("video_location.jav_id IS NULL")
 	}
 	sub = applyDirectoryFilter(sub, "video_location", directoryIDs)
+	sub = applyClosedSubdirectoryFilter(sub, "video_location", closedSubdirs)
 
 	if like != "" {
 		sub = sub.Where("video_location.filename LIKE ? COLLATE NOCASE", like)

--- a/internal/db/videos_test.go
+++ b/internal/db/videos_test.go
@@ -74,7 +74,7 @@ func TestListVideosSortByDurationDirections(t *testing.T) {
 	}
 	createVideoLocationsForVideos(t, db, shortVideo, longVideo)
 
-	items, err := ListVideos(ctx, 20, 0, nil, "", "duration", nil, nil)
+	items, err := ListVideos(ctx, 20, 0, nil, "", "duration", nil, nil, nil)
 	if err != nil {
 		t.Fatalf("ListVideos duration: %v", err)
 	}
@@ -85,7 +85,7 @@ func TestListVideosSortByDurationDirections(t *testing.T) {
 		t.Fatalf("unexpected first video: got %d want %d", items[0].ID, longVideo.ID)
 	}
 
-	items, err = ListVideos(ctx, 20, 0, nil, "", "duration_asc", nil, nil)
+	items, err = ListVideos(ctx, 20, 0, nil, "", "duration_asc", nil, nil, nil)
 	if err != nil {
 		t.Fatalf("ListVideos duration_asc: %v", err)
 	}
@@ -148,7 +148,7 @@ func TestListVideosCanHideRecognizedJav(t *testing.T) {
 		t.Fatalf("create video tags: %v", err)
 	}
 
-	defaultItems, err := ListVideos(ctx, 20, 0, nil, "", "recent", nil, nil)
+	defaultItems, err := ListVideos(ctx, 20, 0, nil, "", "recent", nil, nil, nil)
 	if err != nil {
 		t.Fatalf("ListVideos default: %v", err)
 	}
@@ -168,14 +168,14 @@ func TestListVideosCanHideRecognizedJav(t *testing.T) {
 	if recognized.Jav == nil || recognized.Jav.Code != "ABC-001" {
 		t.Fatalf("recognized video should include jav code: %#v", recognized.Jav)
 	}
-	defaultCount, err := CountVideos(ctx, nil, "", nil)
+	defaultCount, err := CountVideos(ctx, nil, "", nil, nil)
 	if err != nil {
 		t.Fatalf("CountVideos default: %v", err)
 	}
 	if defaultCount != 2 {
 		t.Fatalf("default count should include recognized jav: got %d want 2", defaultCount)
 	}
-	defaultTags, err := ListTags(ctx, nil)
+	defaultTags, err := ListTags(ctx, nil, nil)
 	if err != nil {
 		t.Fatalf("ListTags default: %v", err)
 	}
@@ -183,21 +183,21 @@ func TestListVideosCanHideRecognizedJav(t *testing.T) {
 		t.Fatalf("default tag count should include recognized jav: %#v", defaultTags)
 	}
 
-	hiddenItems, err := ListVideos(ctx, 20, 0, nil, "", "recent", nil, nil, true)
+	hiddenItems, err := ListVideos(ctx, 20, 0, nil, "", "recent", nil, nil, nil, true)
 	if err != nil {
 		t.Fatalf("ListVideos hide jav: %v", err)
 	}
 	if len(hiddenItems) != 1 || hiddenItems[0].ID != plainVideo.ID {
 		t.Fatalf("hide jav list should return only plain videos: %#v", hiddenItems)
 	}
-	hiddenCount, err := CountVideos(ctx, nil, "", nil, true)
+	hiddenCount, err := CountVideos(ctx, nil, "", nil, nil, true)
 	if err != nil {
 		t.Fatalf("CountVideos hide jav: %v", err)
 	}
 	if hiddenCount != 1 {
 		t.Fatalf("hide jav count should return only plain videos: got %d want 1", hiddenCount)
 	}
-	hiddenTags, err := ListTags(ctx, nil, true)
+	hiddenTags, err := ListTags(ctx, nil, nil, true)
 	if err != nil {
 		t.Fatalf("ListTags hide jav: %v", err)
 	}
@@ -400,7 +400,7 @@ func TestVideoLocationsAllowSameVideoInMultipleDirectories(t *testing.T) {
 		t.Fatalf("reconcile: %v", err)
 	}
 
-	items, err := ListVideos(ctx, 20, 0, nil, "", "recent", nil, nil)
+	items, err := ListVideos(ctx, 20, 0, nil, "", "recent", nil, nil, nil)
 	if err != nil {
 		t.Fatalf("ListVideos: %v", err)
 	}
@@ -410,49 +410,49 @@ func TestVideoLocationsAllowSameVideoInMultipleDirectories(t *testing.T) {
 	if len(items[0].Locations) != 1 || len(items[1].Locations) != 1 {
 		t.Fatalf("list rows should be location-level: %#v", items)
 	}
-	count, err := CountVideos(ctx, nil, "", nil)
+	count, err := CountVideos(ctx, nil, "", nil, nil)
 	if err != nil {
 		t.Fatalf("CountVideos: %v", err)
 	}
 	if count != 2 {
 		t.Fatalf("unexpected location count: got %d want 2", count)
 	}
-	dirBItems, err := ListVideos(ctx, 20, 0, nil, "", "recent", nil, []int64{dirB.ID})
+	dirBItems, err := ListVideos(ctx, 20, 0, nil, "", "recent", nil, []int64{dirB.ID}, nil)
 	if err != nil {
 		t.Fatalf("ListVideos dir filter: %v", err)
 	}
 	if len(dirBItems) != 1 || dirBItems[0].LocationID != locB.ID || dirBItems[0].Path != "copies/movie.mp4" {
 		t.Fatalf("unexpected filtered items: %#v", dirBItems)
 	}
-	dirBCount, err := CountVideos(ctx, nil, "", []int64{dirB.ID})
+	dirBCount, err := CountVideos(ctx, nil, "", []int64{dirB.ID}, nil)
 	if err != nil {
 		t.Fatalf("CountVideos dir filter: %v", err)
 	}
 	if dirBCount != 1 {
 		t.Fatalf("unexpected filtered count: got %d want 1", dirBCount)
 	}
-	pathSearchItems, err := ListVideos(ctx, 20, 0, nil, "copies", "recent", nil, nil)
+	pathSearchItems, err := ListVideos(ctx, 20, 0, nil, "copies", "recent", nil, nil, nil)
 	if err != nil {
 		t.Fatalf("ListVideos path search: %v", err)
 	}
 	if len(pathSearchItems) != 0 {
 		t.Fatalf("search should use filename, not relative path directories: %#v", pathSearchItems)
 	}
-	filenameSearchItems, err := ListVideos(ctx, 20, 0, nil, "movie.mp4", "recent", nil, nil)
+	filenameSearchItems, err := ListVideos(ctx, 20, 0, nil, "movie.mp4", "recent", nil, nil, nil)
 	if err != nil {
 		t.Fatalf("ListVideos filename search: %v", err)
 	}
 	if len(filenameSearchItems) != 2 {
 		t.Fatalf("filename search should match both copies: got %d want 2", len(filenameSearchItems))
 	}
-	disabledItems, err := ListVideos(ctx, 20, 0, nil, "", "recent", nil, []int64{0})
+	disabledItems, err := ListVideos(ctx, 20, 0, nil, "", "recent", nil, []int64{0}, nil)
 	if err != nil {
 		t.Fatalf("ListVideos disabled dir filter: %v", err)
 	}
 	if len(disabledItems) != 0 {
 		t.Fatalf("disabled directory filter should return no rows: %#v", disabledItems)
 	}
-	disabledCount, err := CountVideos(ctx, nil, "", []int64{0})
+	disabledCount, err := CountVideos(ctx, nil, "", []int64{0}, nil)
 	if err != nil {
 		t.Fatalf("CountVideos disabled dir filter: %v", err)
 	}

--- a/internal/db/videos_test.go
+++ b/internal/db/videos_test.go
@@ -664,7 +664,7 @@ func assertVideoContentSchema(t *testing.T, db *gorm.DB) {
 		t.Fatalf("iterate video columns: %v", err)
 	}
 
-	wantColumns := []string{"id", "size", "fingerprint", "duration_sec", "play_count", "created_at", "updated_at", "jav_scrape_override", "cover_screenshot_name"}
+	wantColumns := []string{"id", "size", "fingerprint", "duration_sec", "play_count", "created_at", "updated_at", "jav_scrape_override", "cover_screenshot_name", "format"}
 	if len(columns) != len(wantColumns) {
 		t.Fatalf("unexpected video columns: got %#v want %v", columns, wantColumns)
 	}

--- a/internal/models/video.go
+++ b/internal/models/video.go
@@ -4,26 +4,29 @@ import "time"
 
 // Video represents metadata tracked for a single video content entity.
 type Video struct {
-	ID                  int64           `json:"id" gorm:"primaryKey"`
-	LocationID          int64           `json:"location_id,omitempty" gorm:"-"`
-	DirectoryID         int64           `json:"directory_id" gorm:"-"`
-	Path                string          `json:"path" gorm:"-"` // Deprecated: derived from VideoLocation for API compatibility.
-	Filename            string          `json:"filename" gorm:"-"`
-	Size                int64           `json:"size"`
-	ModifiedAt          time.Time       `json:"modified_at" gorm:"-"`
-	Fingerprint         string          `json:"fingerprint" gorm:"uniqueIndex"`
-	DurationSec         int64           `json:"duration_sec"` // duration in seconds (rounded)
-	PlayCount           int64           `json:"play_count" gorm:"not null;default:0"`
-	CreatedAt           time.Time       `json:"created_at"`
-	UpdatedAt           time.Time       `json:"updated_at"`
-	JavScrapeOverride   string          `json:"jav_scrape_override"`
-	CoverScreenshotName string          `json:"cover_screenshot_name"`
-	Tags                []Tag           `json:"tags,omitempty" gorm:"many2many:video_tag"`
-	JavID               *int64          `json:"jav_id" gorm:"-"`
-	Jav                 *Jav            `json:"jav,omitempty" gorm:"-"`
-	DirectoryRef        Directory       `json:"directory,omitempty" gorm:"-"`
-	Locations           []VideoLocation `json:"locations,omitempty" gorm:"foreignKey:VideoID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`
-	Hidden              bool            `json:"hidden" gorm:"-"`
+	ID                  int64     `json:"id" gorm:"primaryKey"`
+	LocationID          int64     `json:"location_id,omitempty" gorm:"-"`
+	DirectoryID         int64     `json:"directory_id" gorm:"-"`
+	Path                string    `json:"path" gorm:"-"` // Deprecated: derived from VideoLocation for API compatibility.
+	Filename            string    `json:"filename" gorm:"-"`
+	Size                int64     `json:"size"`
+	ModifiedAt          time.Time `json:"modified_at" gorm:"-"`
+	Fingerprint         string    `json:"fingerprint" gorm:"uniqueIndex"`
+	DurationSec         int64     `json:"duration_sec"` // duration in seconds (rounded)
+	PlayCount           int64     `json:"play_count" gorm:"not null;default:0"`
+	CreatedAt           time.Time `json:"created_at"`
+	UpdatedAt           time.Time `json:"updated_at"`
+	JavScrapeOverride   string    `json:"jav_scrape_override"`
+	CoverScreenshotName string    `json:"cover_screenshot_name"`
+	// Format is the actual container format detected by ffprobe (e.g. ts/mkv),
+	// independent of the file extension, so renamed streams are still labeled correctly.
+	Format       string          `json:"format"`
+	Tags         []Tag           `json:"tags,omitempty" gorm:"many2many:video_tag"`
+	JavID        *int64          `json:"jav_id" gorm:"-"`
+	Jav          *Jav            `json:"jav,omitempty" gorm:"-"`
+	DirectoryRef Directory       `json:"directory,omitempty" gorm:"-"`
+	Locations    []VideoLocation `json:"locations,omitempty" gorm:"foreignKey:VideoID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`
+	Hidden       bool            `json:"hidden" gorm:"-"`
 }
 
 const JavScrapeOverrideSkip = ":skip"

--- a/internal/runtimeconfig/runtimeconfig.go
+++ b/internal/runtimeconfig/runtimeconfig.go
@@ -23,8 +23,49 @@ func DisableDirectoryPicker() bool {
 	return ContainerMode() || envBool("JAVBOSS_DISABLE_DIRECTORY_PICKER")
 }
 
+// HostAgentURL returns the base URL of a host-side agent (e.g.
+// http://host.docker.internal:17655) that opens files on the host machine.
+// When set while running inside a container, desktop integration is kept
+// enabled and file-open requests are forwarded to that agent.
+func HostAgentURL() string {
+	return strings.TrimSpace(os.Getenv("JAVBOSS_HOST_AGENT_URL"))
+}
+
+// HostAgentToken returns the shared token used to authenticate requests to
+// the host-side agent. Empty means the agent does not require a token.
+func HostAgentToken() string {
+	return strings.TrimSpace(os.Getenv("JAVBOSS_HOST_AGENT_TOKEN"))
+}
+
+// HostAgentPathPrefix returns the container-side mount prefix that maps to
+// the host filesystem root. The prefix is stripped from container paths
+// before they are sent to the host agent. Defaults to /host.
+func HostAgentPathPrefix() string {
+	prefix := strings.TrimSpace(os.Getenv("JAVBOSS_HOST_AGENT_PATH_PREFIX"))
+	if prefix == "" {
+		return "/host"
+	}
+	return strings.TrimRight(prefix, "/")
+}
+
+// HostAgentPathMap returns explicit container-prefix to host-prefix mappings
+// ("containerPrefix=hostPrefix" entries separated by ';'). These are applied
+// before the generic HostAgentPathPrefix fallback.
+func HostAgentPathMap() string {
+	return strings.TrimSpace(os.Getenv("JAVBOSS_HOST_AGENT_PATH_MAP"))
+}
+
+// HostAgentConfigured reports whether a host-side agent is available to open
+// files on the host machine.
+func HostAgentConfigured() bool {
+	return HostAgentURL() != ""
+}
+
 func DisableDesktopIntegration() bool {
-	return ContainerMode() || envBool("JAVBOSS_DISABLE_DESKTOP_INTEGRATION")
+	if envBool("JAVBOSS_DISABLE_DESKTOP_INTEGRATION") {
+		return true
+	}
+	return ContainerMode() && !HostAgentConfigured()
 }
 
 func DisableMPVPlayback() bool {

--- a/internal/runtimeconfig/runtimeconfig_test.go
+++ b/internal/runtimeconfig/runtimeconfig_test.go
@@ -1,0 +1,73 @@
+package runtimeconfig
+
+import (
+	"testing"
+)
+
+func TestDisableDesktopIntegrationWithHostAgent(t *testing.T) {
+	t.Setenv("JAVBOSS_CONTAINER", "1")
+	t.Setenv("JAVBOSS_DOCKER", "")
+	t.Setenv("JAVBOSS_DISABLE_DESKTOP_INTEGRATION", "")
+
+	// Container without agent: desktop integration disabled.
+	t.Setenv("JAVBOSS_HOST_AGENT_URL", "")
+	if !DisableDesktopIntegration() {
+		t.Fatal("expected desktop integration disabled in container without host agent")
+	}
+
+	// Container with host agent: desktop integration stays enabled.
+	t.Setenv("JAVBOSS_HOST_AGENT_URL", "http://host.docker.internal:17655")
+	if DisableDesktopIntegration() {
+		t.Fatal("expected desktop integration enabled when host agent is configured")
+	}
+
+	// Explicit disable flag still wins.
+	t.Setenv("JAVBOSS_DISABLE_DESKTOP_INTEGRATION", "1")
+	if !DisableDesktopIntegration() {
+		t.Fatal("expected desktop integration disabled when explicitly disabled")
+	}
+
+	// Native (non-container) mode is unaffected.
+	t.Setenv("JAVBOSS_CONTAINER", "")
+	t.Setenv("JAVBOSS_DISABLE_DESKTOP_INTEGRATION", "")
+	if DisableDesktopIntegration() {
+		t.Fatal("expected desktop integration enabled in native mode")
+	}
+}
+
+func TestHostAgentConfig(t *testing.T) {
+	t.Setenv("JAVBOSS_HOST_AGENT_URL", " http://host.docker.internal:17655 ")
+	if got := HostAgentURL(); got != "http://host.docker.internal:17655" {
+		t.Fatalf("HostAgentURL = %q", got)
+	}
+	if !HostAgentConfigured() {
+		t.Fatal("expected HostAgentConfigured true")
+	}
+
+	t.Setenv("JAVBOSS_HOST_AGENT_PATH_PREFIX", "/mnt/host/")
+	if got := HostAgentPathPrefix(); got != "/mnt/host" {
+		t.Fatalf("HostAgentPathPrefix = %q", got)
+	}
+	t.Setenv("JAVBOSS_HOST_AGENT_PATH_PREFIX", "")
+	if got := HostAgentPathPrefix(); got != "/host" {
+		t.Fatalf("default HostAgentPathPrefix = %q", got)
+	}
+
+	t.Setenv("JAVBOSS_HOST_AGENT_TOKEN", "  secret  ")
+	if got := HostAgentToken(); got != "secret" {
+		t.Fatalf("HostAgentToken = %q", got)
+	}
+}
+
+func TestContainerMode(t *testing.T) {
+	t.Setenv("JAVBOSS_CONTAINER", "")
+	t.Setenv("JAVBOSS_DOCKER", "1")
+	if !ContainerMode() {
+		t.Fatal("expected JAVBOSS_DOCKER=1 to enable container mode")
+	}
+	t.Setenv("JAVBOSS_DOCKER", "")
+	t.Setenv("JAVBOSS_CONTAINER", "0")
+	if ContainerMode() {
+		t.Fatal("expected JAVBOSS_CONTAINER=0 to disable container mode")
+	}
+}

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -42,6 +42,7 @@ func RegisterRoutes(router gin.IRoutes) {
 	router.POST("/directories", createDirectory)
 	router.POST("/directories/pick", pickDirectory)
 	router.POST("/directories/:id/process", processDirectory)
+	router.GET("/directories/:id/subdirectories", listDirectorySubdirectories)
 	router.PATCH("/directories/:id", updateDirectory)
 
 	router.GET("/tags", listTags)

--- a/internal/server/config_api.go
+++ b/internal/server/config_api.go
@@ -406,6 +406,7 @@ func applyRuntimeConfigFields(cfg map[string]string) {
 	cfg["desktop_integration_enabled"] = strconv.FormatBool(!runtimeconfig.DisableDesktopIntegration())
 	cfg["mpv_enabled"] = strconv.FormatBool(!runtimeconfig.DisableMPVPlayback())
 	cfg["browser_playback_only"] = strconv.FormatBool(runtimeconfig.DisableMPVPlayback() && runtimeconfig.DisableDesktopIntegration())
+	cfg["host_agent_configured"] = strconv.FormatBool(runtimeconfig.HostAgentConfigured())
 	cfg["host_path_prefix_enabled"] = strconv.FormatBool(runtimeconfig.HostPathPrefixEnabled())
 }
 

--- a/internal/server/directory_api.go
+++ b/internal/server/directory_api.go
@@ -42,6 +42,32 @@ func listDirectories(c *gin.Context) {
 	c.JSON(http.StatusOK, response)
 }
 
+func listDirectorySubdirectories(c *gin.Context) {
+	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil || id <= 0 {
+		respondLocalizedError(c, http.StatusBadRequest, "目录 ID 无效", "Invalid directory ID")
+		return
+	}
+	dir, err := dbpkg.GetDirectory(c.Request.Context(), id)
+	if err != nil {
+		logging.Error("get directory for subdirectories failed id=%d err=%v", id, err)
+		respondLocalizedError(c, http.StatusInternalServerError, "读取目录失败", "Failed to load directory")
+		return
+	}
+	if dir == nil || dir.IsDelete {
+		respondLocalizedError(c, http.StatusNotFound, "目录不存在", "Directory does not exist")
+		return
+	}
+
+	result, err := dbpkg.ListDirectorySubdirectories(c.Request.Context(), id)
+	if err != nil {
+		logging.Error("list directory subdirectories failed id=%d err=%v", id, err)
+		respondLocalizedError(c, http.StatusInternalServerError, "加载子目录失败", "Failed to load subdirectories")
+		return
+	}
+	c.JSON(http.StatusOK, result)
+}
+
 func createDirectory(c *gin.Context) {
 	var req struct {
 		Path string `json:"path"`

--- a/internal/server/directory_subdir_api_test.go
+++ b/internal/server/directory_subdir_api_test.go
@@ -1,0 +1,87 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"javboss/internal/common"
+	dbpkg "javboss/internal/db"
+	"javboss/internal/models"
+)
+
+func TestListDirectorySubdirectoriesHandler(t *testing.T) {
+	database, err := dbpkg.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open test database: %v", err)
+	}
+	previousDB := common.DB
+	common.DB = database
+	t.Cleanup(func() {
+		common.DB = previousDB
+		if sqlDB, dbErr := database.DB(); dbErr == nil {
+			_ = sqlDB.Close()
+		}
+	})
+
+	ctx := context.Background()
+	dir := models.Directory{Path: "/media/subdir-api"}
+	if err := database.Create(&dir).Error; err != nil {
+		t.Fatalf("create directory: %v", err)
+	}
+	for i, rel := range []string{"root.mp4", "JAV/IPX-001.mp4", "JAV/IPX-002.mp4"} {
+		video := models.Video{Fingerprint: "subdir-api-" + string(rune('a'+i))}
+		if err := database.Create(&video).Error; err != nil {
+			t.Fatalf("create video: %v", err)
+		}
+		if _, err := dbpkg.UpsertVideoLocation(
+			ctx,
+			video.ID,
+			dir.ID,
+			rel,
+			time.Unix(1710000000, 0).UTC(),
+		); err != nil {
+			t.Fatalf("upsert location %s: %v", rel, err)
+		}
+	}
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.GET("/directories/:id/subdirectories", listDirectorySubdirectories)
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(
+		http.MethodGet,
+		"/directories/"+strconv.FormatInt(dir.ID, 10)+"/subdirectories",
+		nil,
+	)
+	router.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 body=%s", recorder.Code, recorder.Body.String())
+	}
+	var payload dbpkg.DirectorySubdirectories
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v body=%s", err, recorder.Body.String())
+	}
+	if payload.RootVideoCount != 1 {
+		t.Fatalf("root video count = %d, want 1", payload.RootVideoCount)
+	}
+	if len(payload.Subdirectories) != 1 || payload.Subdirectories[0].Name != "JAV" || payload.Subdirectories[0].VideoCount != 2 {
+		t.Fatalf("subdirectories = %#v, want JAV with 2 videos", payload.Subdirectories)
+	}
+
+	// Unknown directory id returns 404.
+	recorder = httptest.NewRecorder()
+	request = httptest.NewRequest(http.MethodGet, "/directories/99999/subdirectories", nil)
+	router.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusNotFound {
+		t.Fatalf("unknown directory status = %d, want 404", recorder.Code)
+	}
+}

--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
+
+	dbpkg "javboss/internal/db"
 )
 
 func queryInt(c *gin.Context, key string, def int) int {
@@ -86,6 +88,38 @@ func parseInt64CSV(s string) []int64 {
 		}
 		seen[value] = struct{}{}
 		out = append(out, value)
+	}
+	return out
+}
+
+// parseClosedSubdirectories parses a "closed_subdirs" query value with the format
+// "<directoryId>:<subdirName>,<directoryId>:<subdirName>,...". Names are split on the
+// first colon so colons inside a name are preserved.
+func parseClosedSubdirectories(s string) []dbpkg.ClosedSubdirectory {
+	if strings.TrimSpace(s) == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]dbpkg.ClosedSubdirectory, 0, len(parts))
+	for _, part := range parts {
+		clean := strings.TrimSpace(part)
+		if clean == "" {
+			continue
+		}
+		idx := strings.IndexByte(clean, ':')
+		if idx <= 0 {
+			continue
+		}
+		id, err := strconv.ParseInt(strings.TrimSpace(clean[:idx]), 10, 64)
+		if err != nil || id <= 0 {
+			continue
+		}
+		name := strings.TrimSpace(clean[idx+1:])
+		// Name is a relative path (slash-separated) for multi-level subdirectories.
+		if name == "" || strings.Contains(name, "\\") || strings.HasPrefix(name, "/") || strings.HasSuffix(name, "/") || strings.Contains(name, "//") {
+			continue
+		}
+		out = append(out, dbpkg.ClosedSubdirectory{DirectoryID: id, Name: name})
 	}
 	return out
 }

--- a/internal/server/jav_api.go
+++ b/internal/server/jav_api.go
@@ -69,7 +69,7 @@ func searchJav(c *gin.Context) {
 		seed = &parsed
 	}
 
-	items, total, err := dbpkg.SearchJavWithPrefix(c.Request.Context(), idolIDs, tagIDs, search, prefix, sort, limit, offset, seed, directoryIDs, studioID, seriesID, boolInt64(soloOnly), favoriteGroupID)
+	items, total, err := dbpkg.SearchJavWithPrefix(c.Request.Context(), idolIDs, tagIDs, search, prefix, sort, limit, offset, seed, directoryIDs, parseClosedSubdirectories(c.Query("closed_subdirs")), studioID, seriesID, boolInt64(soloOnly), favoriteGroupID)
 	if err != nil {
 		logging.Error("SearchJav: %v", err)
 		respondLocalizedError(c, http.StatusInternalServerError, "搜索 JAV 作品失败", "Failed to search JAV items")
@@ -224,7 +224,7 @@ func javSampleImagesToModel(info *jav.JavInfo) models.JavSampleImages {
 }
 
 func listJavTags(c *gin.Context) {
-	tags, err := dbpkg.ListJavTags(c.Request.Context(), parseDirectoryIDs(c.Query("directory_ids")))
+	tags, err := dbpkg.ListJavTags(c.Request.Context(), parseDirectoryIDs(c.Query("directory_ids")), parseClosedSubdirectories(c.Query("closed_subdirs")))
 	if err != nil {
 		logging.Error("list jav tags error: %v", err)
 		respondLocalizedError(c, http.StatusInternalServerError, "加载 JAV 标签失败", "Failed to load JAV tags")

--- a/internal/server/jav_idol_api.go
+++ b/internal/server/jav_idol_api.go
@@ -35,7 +35,7 @@ func listJavIdols(c *gin.Context) {
 		favoriteGroupID = parsed
 	}
 
-	items, total, err := dbpkg.ListJavIdols(c.Request.Context(), search, sort, limit, offset, directoryIDs, favoriteGroupID)
+	items, total, err := dbpkg.ListJavIdols(c.Request.Context(), search, sort, limit, offset, directoryIDs, parseClosedSubdirectories(c.Query("closed_subdirs")), favoriteGroupID)
 	if err != nil {
 		logging.Error("list jav idols: %v", err)
 		respondLocalizedError(c, http.StatusInternalServerError, "加载女优列表失败", "Failed to load idols")

--- a/internal/server/jav_studio_api.go
+++ b/internal/server/jav_studio_api.go
@@ -32,7 +32,7 @@ func listJavStudios(c *gin.Context) {
 		favoriteGroupID = parsed
 	}
 
-	items, total, err := dbpkg.ListJavStudios(c.Request.Context(), search, limit, offset, directoryIDs, favoriteGroupID)
+	items, total, err := dbpkg.ListJavStudios(c.Request.Context(), search, limit, offset, directoryIDs, parseClosedSubdirectories(c.Query("closed_subdirs")), favoriteGroupID)
 	if err != nil {
 		logging.Error("list jav studios: %v", err)
 		respondLocalizedError(c, http.StatusInternalServerError, "加载片商列表失败", "Failed to load studios")
@@ -168,7 +168,7 @@ func listJavSeries(c *gin.Context) {
 		favoriteGroupID = parsed
 	}
 
-	items, total, err := dbpkg.ListJavSeries(c.Request.Context(), search, limit, offset, directoryIDs, favoriteGroupID)
+	items, total, err := dbpkg.ListJavSeries(c.Request.Context(), search, limit, offset, directoryIDs, parseClosedSubdirectories(c.Query("closed_subdirs")), favoriteGroupID)
 	if err != nil {
 		logging.Error("list jav series: %v", err)
 		respondLocalizedError(c, http.StatusInternalServerError, "加载系列列表失败", "Failed to load series")

--- a/internal/server/tag_api.go
+++ b/internal/server/tag_api.go
@@ -28,6 +28,7 @@ func listTags(c *gin.Context) {
 	tags, err := dbpkg.ListTags(
 		c.Request.Context(),
 		parseDirectoryIDs(c.Query("directory_ids")),
+		parseClosedSubdirectories(c.Query("closed_subdirs")),
 		queryBool(c, "hide_jav", false),
 	)
 	if err != nil {

--- a/internal/server/video_api.go
+++ b/internal/server/video_api.go
@@ -31,6 +31,7 @@ func listVideos(c *gin.Context) {
 	offset := queryInt(c, "offset", 0)
 	tagFilter := parseTagQuery(c.Query("tags"))
 	directoryIDs := parseDirectoryIDs(c.Query("directory_ids"))
+	closedSubdirs := parseClosedSubdirectories(c.Query("closed_subdirs"))
 	search := strings.TrimSpace(c.Query("search"))
 	sort := strings.TrimSpace(c.Query("sort"))
 	hideJav := queryBool(c, "hide_jav", false)
@@ -45,14 +46,14 @@ func listVideos(c *gin.Context) {
 		seed = &parsed
 	}
 
-	videos, err := dbpkg.ListVideos(c.Request.Context(), limit, offset, tagFilter, search, sort, seed, directoryIDs, hideJav)
+	videos, err := dbpkg.ListVideos(c.Request.Context(), limit, offset, tagFilter, search, sort, seed, directoryIDs, closedSubdirs, hideJav)
 	if err != nil {
 		logging.Error("list videos error: %v", err)
 		respondLocalizedError(c, http.StatusInternalServerError, "加载视频列表失败", "Failed to load videos")
 		return
 	}
 
-	total, err := dbpkg.CountVideos(c.Request.Context(), tagFilter, search, directoryIDs, hideJav)
+	total, err := dbpkg.CountVideos(c.Request.Context(), tagFilter, search, directoryIDs, closedSubdirs, hideJav)
 	if err != nil {
 		logging.Error("count videos error: %v", err)
 		respondLocalizedError(c, http.StatusInternalServerError, "统计视频数量失败", "Failed to count videos")

--- a/internal/service/directory_scanner.go
+++ b/internal/service/directory_scanner.go
@@ -31,6 +31,7 @@ type FileEntry struct {
 	Fingerprint   string
 	PathKey       string
 	DurationSec   int64
+	Format        string
 }
 
 // Summary captures the results of a directory synchronisation run.
@@ -338,7 +339,11 @@ func walkDirectoryAndSync(ctx context.Context, directory models.Directory, state
 				} else {
 					state.javLinks.Enqueue(existingLoc.ID)
 				}
-				return nil
+				// 旧库视频尚未记录真实容器格式时，不跳过探测：继续走下方 probe
+				// 流程以回填 format（文件未变时正常跳过；已回填后恢复跳过）
+				if existingVideo.Format != "" {
+					return nil
+				}
 			}
 		}
 
@@ -365,6 +370,7 @@ func walkDirectoryAndSync(ctx context.Context, directory models.Directory, state
 			ModifiedAt:    modTime,
 			Fingerprint:   fingerprint,
 			DurationSec:   durationSec,
+			Format:        meta.Container,
 		}
 
 		return upsertVideo(ctx, fileEntry, state, summary)
@@ -395,6 +401,13 @@ func upsertVideo(ctx context.Context, entry *FileEntry, state *syncState, summar
 			logging.Error("save video location failed, skip: path=%s err=%v", entry.AbsolutePath, err)
 			return nil
 		}
+		// 回填旧库：首次扫描时探测到的真实容器格式（如 TS 流改名 .mp4）
+		if video.Format == "" && entry.Format != "" {
+			video.Format = entry.Format
+			if err := db.SaveVideo(ctx, video); err != nil {
+				logging.Error("backfill video format failed: id=%d err=%v", video.ID, err)
+			}
+		}
 		return nil
 	}
 
@@ -403,6 +416,7 @@ func upsertVideo(ctx context.Context, entry *FileEntry, state *syncState, summar
 		Size:        entry.Size,
 		Fingerprint: entry.Fingerprint,
 		DurationSec: entry.DurationSec,
+		Format:      entry.Format,
 	}
 
 	if err := db.CreateVideo(ctx, video); err != nil {

--- a/internal/util/hostagent.go
+++ b/internal/util/hostagent.go
@@ -1,0 +1,134 @@
+package util
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"javboss/internal/common/logging"
+	"javboss/internal/runtimeconfig"
+)
+
+// hostAgentTimeout bounds how long a single agent call may take. Opening a
+// file on the host is normally instant, but the host might be unreachable.
+const hostAgentTimeout = 5 * time.Second
+
+var (
+	// ErrHostAgentUnavailable is returned when no host agent is configured.
+	ErrHostAgentUnavailable = errors.New("host agent not configured")
+
+	hostAgentHTTPClient = &http.Client{
+		Timeout: hostAgentTimeout,
+		Transport: &http.Transport{
+			Proxy: nil, // never route agent traffic through a proxy
+		},
+	}
+)
+
+// MapContainerPathToHost converts a container-side path to the host path that
+// the host agent should open. Explicit mappings from JAVBOSS_HOST_AGENT_PATH_MAP
+// (entries "containerPrefix=hostPrefix" separated by ';') are applied first;
+// otherwise the JAVBOSS_HOST_AGENT_PATH_PREFIX (default /host) is stripped.
+func MapContainerPathToHost(p string) string {
+	raw := strings.TrimSpace(p)
+	if raw == "" {
+		return raw
+	}
+	for _, entry := range strings.Split(runtimeconfig.HostAgentPathMap(), ";") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		containerPrefix, hostPrefix, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+		containerPrefix = strings.TrimRight(strings.TrimSpace(containerPrefix), "/")
+		hostPrefix = strings.TrimSpace(hostPrefix)
+		if containerPrefix == "" || hostPrefix == "" {
+			continue
+		}
+		if raw == containerPrefix {
+			return hostPrefix
+		}
+		if strings.HasPrefix(raw, containerPrefix+"/") {
+			rest := raw[len(containerPrefix):]
+			if strings.Contains(hostPrefix, "\\") {
+				rest = filepath.FromSlash(rest)
+			}
+			return hostPrefix + rest
+		}
+	}
+	prefix := runtimeconfig.HostAgentPathPrefix()
+	if prefix == "" {
+		return raw
+	}
+	if raw == prefix {
+		return "/"
+	}
+	if strings.HasPrefix(raw, prefix+"/") {
+		return raw[len(prefix):]
+	}
+	return raw
+}
+
+// openViaHostAgent asks the host-side agent to open the file with the host's
+// default application. It reports handled=false when no agent is configured,
+// so callers can fall back to opening the file locally.
+func openViaHostAgent(containerPath string) (bool, error) {
+	return callHostAgent("open", containerPath)
+}
+
+// revealViaHostAgent asks the host-side agent to reveal the file in its
+// containing folder on the host.
+func revealViaHostAgent(containerPath string) (bool, error) {
+	return callHostAgent("reveal", containerPath)
+}
+
+func callHostAgent(action, containerPath string) (bool, error) {
+	baseURL := runtimeconfig.HostAgentURL()
+	if baseURL == "" {
+		return false, ErrHostAgentUnavailable
+	}
+	base, err := url.Parse(baseURL)
+	if err != nil || base.Scheme == "" || base.Host == "" {
+		return true, fmt.Errorf("invalid host agent URL %q: %w", baseURL, err)
+	}
+	hostPath := MapContainerPathToHost(containerPath)
+	body, err := json.Marshal(map[string]string{"path": hostPath})
+	if err != nil {
+		return true, fmt.Errorf("encode host agent request: %w", err)
+	}
+	endpoint := *base
+	endpoint.Path = strings.TrimRight(endpoint.Path, "/") + "/api/" + action
+	req, err := http.NewRequest(http.MethodPost, endpoint.String(), bytes.NewReader(body))
+	if err != nil {
+		return true, fmt.Errorf("build host agent request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if token := runtimeconfig.HostAgentToken(); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	logging.Info("host agent %s: container path %q -> host path %q", action, containerPath, hostPath)
+	resp, err := hostAgentHTTPClient.Do(req)
+	if err != nil {
+		return true, fmt.Errorf("host agent %s: %w", action, err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if resp.StatusCode != http.StatusOK {
+		detail := strings.TrimSpace(string(respBody))
+		if detail == "" {
+			detail = resp.Status
+		}
+		return true, fmt.Errorf("host agent %s failed: %s", action, detail)
+	}
+	return true, nil
+}

--- a/internal/util/hostagent_test.go
+++ b/internal/util/hostagent_test.go
@@ -1,0 +1,164 @@
+package util
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestMapContainerPathToHostDefaultPrefix(t *testing.T) {
+	t.Setenv("JAVBOSS_HOST_AGENT_PATH_PREFIX", "")
+	t.Setenv("JAVBOSS_HOST_AGENT_PATH_MAP", "")
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"strip /host", "/host/mnt/disk1/a.mp4", "/mnt/disk1/a.mp4"},
+		{"strip /host root", "/host", "/"},
+		{"strip /host root with slash", "/host/", "/"},
+		{"no prefix unchanged", "/data/a.mp4", "/data/a.mp4"},
+		{"empty", "", ""},
+		{"windows style unchanged", `C:\media\a.mp4`, `C:\media\a.mp4`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := MapContainerPathToHost(tc.in); got != tc.want {
+				t.Fatalf("MapContainerPathToHost(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMapContainerPathToHostCustomPrefix(t *testing.T) {
+	t.Setenv("JAVBOSS_HOST_AGENT_PATH_PREFIX", "/mnt/host")
+	t.Setenv("JAVBOSS_HOST_AGENT_PATH_MAP", "")
+
+	if got, want := MapContainerPathToHost("/mnt/host/media/a.mp4"), "/media/a.mp4"; got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+	if got, want := MapContainerPathToHost("/unrelated/a.mp4"), "/unrelated/a.mp4"; got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestMapContainerPathToHostExplicitMap(t *testing.T) {
+	t.Setenv("JAVBOSS_HOST_AGENT_PATH_MAP", `/host/d=D:\media;/host/e=E:\media`)
+	t.Setenv("JAVBOSS_HOST_AGENT_PATH_PREFIX", "/host")
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"map d drive", "/host/d/a/b.mp4", `D:\media\a\b.mp4`},
+		{"map e drive", "/host/e/x.mp4", `E:\media\x.mp4`},
+		{"map root", "/host/d", `D:\media`},
+		{"unmapped falls back to strip prefix", "/host/other/x.mp4", "/other/x.mp4"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := MapContainerPathToHost(tc.in); got != tc.want {
+				t.Fatalf("MapContainerPathToHost(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMapContainerPathToHostWindowsHostPrefix(t *testing.T) {
+	t.Setenv("JAVBOSS_HOST_AGENT_PATH_PREFIX", "")
+	t.Setenv("JAVBOSS_HOST_AGENT_PATH_MAP", `/host/d=D:\media`)
+	got := MapContainerPathToHost("/host/d/a.mp4")
+	want := filepath.FromSlash(`D:\media\a.mp4`)
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestCallHostAgent(t *testing.T) {
+	t.Setenv("JAVBOSS_HOST_AGENT_URL", "")
+	t.Setenv("JAVBOSS_HOST_AGENT_TOKEN", "")
+	t.Setenv("JAVBOSS_HOST_AGENT_PATH_PREFIX", "/host")
+
+	var receivedPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req struct {
+			Path string `json:"path"`
+		}
+		_ = json.Unmarshal(body, &req)
+		receivedPath = req.Path
+		if r.URL.Path != "/api/open" {
+			http.Error(w, "unexpected path", http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer server.Close()
+	t.Setenv("JAVBOSS_HOST_AGENT_URL", server.URL)
+
+	handled, err := openViaHostAgent("/host/mnt/a.mp4")
+	if err != nil {
+		t.Fatalf("openViaHostAgent: %v", err)
+	}
+	if !handled {
+		t.Fatal("expected handled=true")
+	}
+	if want := "/mnt/a.mp4"; receivedPath != want {
+		t.Fatalf("agent received path %q, want %q", receivedPath, want)
+	}
+
+	// Without an agent URL, handled=false and ErrHostAgentUnavailable is returned.
+	t.Setenv("JAVBOSS_HOST_AGENT_URL", "")
+	handled, err = openViaHostAgent("/host/mnt/a.mp4")
+	if err != ErrHostAgentUnavailable {
+		t.Fatalf("err = %v, want ErrHostAgentUnavailable", err)
+	}
+	if handled {
+		t.Fatal("expected handled=false")
+	}
+}
+
+func TestCallHostAgentToken(t *testing.T) {
+	t.Setenv("JAVBOSS_HOST_AGENT_TOKEN", "secret")
+	t.Setenv("JAVBOSS_HOST_AGENT_PATH_PREFIX", "/host")
+
+	var gotAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+	t.Setenv("JAVBOSS_HOST_AGENT_URL", server.URL)
+
+	if _, err := openViaHostAgent("/host/mnt/a.mp4"); err != nil {
+		t.Fatalf("openViaHostAgent: %v", err)
+	}
+	if want := "Bearer secret"; gotAuth != want {
+		t.Fatalf("Authorization = %q, want %q", gotAuth, want)
+	}
+}
+
+func TestCallHostAgentError(t *testing.T) {
+	t.Setenv("JAVBOSS_HOST_AGENT_TOKEN", "")
+	t.Setenv("JAVBOSS_HOST_AGENT_PATH_PREFIX", "/host")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+	t.Setenv("JAVBOSS_HOST_AGENT_URL", server.URL)
+
+	handled, err := openViaHostAgent("/host/mnt/a.mp4")
+	if !handled {
+		t.Fatal("expected handled=true even on agent error")
+	}
+	if err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("err = %v, want error mentioning boom", err)
+	}
+}

--- a/internal/util/open.go
+++ b/internal/util/open.go
@@ -6,8 +6,16 @@ import (
 	"os/exec"
 )
 
-// OpenFile opens a file with the system default application.
+// OpenFile opens a file with the system default application. When running
+// inside a container with a host agent configured, the request is forwarded
+// to the agent so the file opens on the host machine.
 func OpenFile(path string) error {
+	if handled, err := openViaHostAgent(path); handled {
+		if err != nil {
+			return fmt.Errorf("open file via host agent: %w", err)
+		}
+		return nil
+	}
 	if handled, err := openFileDirect(path); handled {
 		if err != nil {
 			return fmt.Errorf("open file: %w", err)
@@ -25,7 +33,15 @@ func OpenFile(path string) error {
 }
 
 // RevealFile opens the containing folder and highlights the file when supported.
+// When running inside a container with a host agent configured, the request is
+// forwarded to the agent so the folder opens on the host machine.
 func RevealFile(path string) error {
+	if handled, err := revealViaHostAgent(path); handled {
+		if err != nil {
+			return fmt.Errorf("reveal file via host agent: %w", err)
+		}
+		return nil
+	}
 	cmd, err := buildOpenCommand(path, true)
 	if err != nil {
 		return err

--- a/internal/util/video.go
+++ b/internal/util/video.go
@@ -490,7 +490,44 @@ func normalizeFormatName(raw string) string {
 }
 
 func detectContainer(formatName, path string) string {
-	switch strings.ToLower(strings.TrimSpace(filepath.Ext(path))) {
+	ext := strings.ToLower(strings.TrimSpace(filepath.Ext(path)))
+	real := normalizeFormatName(formatName)
+
+	// 优先采用 ffprobe 探测到的真实容器格式，防止扩展名与内容不符导致误判：
+	// 例如把 MPEG-TS 流改名为 .mp4 后，若仅按扩展名判定为 mp4，浏览器 <video>
+	// 会直接尝试播放 TS 数据而失败（本项目因此类文件只能走 HLS 转封装通道）。
+	switch real {
+	case "mov", "mp4", "m4a", "3gp", "3g2", "mj2":
+		// MP4 家族（含 .mov/.m4v/.3gp 等），浏览器可直接播放
+		return "mp4"
+	case "matroska", "webm":
+		// ffprobe 对 MKV 与 WebM 均报告 "matroska,webm"，用扩展名区分
+		if ext == ".webm" {
+			return "webm"
+		}
+		return "mkv"
+	case "mpegts":
+		// TS 传输流（含蓝光 M2TS），浏览器无法直接播放，需走 HLS 等转封装通道
+		if ext == ".m2ts" || ext == ".mts" {
+			return "m2ts"
+		}
+		return "ts"
+	case "rm":
+		if ext == ".rmvb" || ext == ".rm" {
+			return "rmvb"
+		}
+		return "rm"
+	case "asf":
+		return "wmv"
+	}
+	if real != "" {
+		// 其余情况以探测到的真实格式为准（如 avi/flv/mpeg 等），
+		// 防止扩展名与内容不符（如 MKV 改名 .mp4）导致误判
+		return real
+	}
+
+	// 探测失败时退回扩展名判断
+	switch ext {
 	case ".mp4", ".m4v":
 		return "mp4"
 	case ".mov":
@@ -514,5 +551,5 @@ func detectContainer(formatName, path string) string {
 	case ".mpg", ".mpeg":
 		return "mpeg"
 	}
-	return normalizeFormatName(formatName)
+	return ""
 }

--- a/internal/util/video_test.go
+++ b/internal/util/video_test.go
@@ -130,6 +130,83 @@ func TestDetectContainerRecognizesRMVBExtension(t *testing.T) {
 	}
 }
 
+func TestDetectContainerPrefersRealFormatOverMisleadingExtension(t *testing.T) {
+	tests := []struct {
+		name       string
+		formatName string
+		path       string
+		want       string
+	}{
+		{
+			name:       "mpegts renamed to mp4 (browser direct playback regression)",
+			formatName: "mpegts",
+			path:       "/videos/MEYD-255.mp4",
+			want:       "ts",
+		},
+		{
+			name:       "real mp4 keeps direct playback",
+			formatName: "mov,mp4,m4a,3gp,3g2,mj2",
+			path:       "/videos/JUR-633.mp4",
+			want:       "mp4",
+		},
+		{
+			name:       "quicktime mov maps to mp4 family",
+			formatName: "mov,mp4,m4a,3gp,3g2,mj2",
+			path:       "/videos/sample.mov",
+			want:       "mp4",
+		},
+		{
+			name:       "matroska with mkv extension",
+			formatName: "matroska,webm",
+			path:       "/videos/sample.mkv",
+			want:       "mkv",
+		},
+		{
+			name:       "matroska with webm extension",
+			formatName: "matroska,webm",
+			path:       "/videos/sample.webm",
+			want:       "webm",
+		},
+		{
+			name:       "mpegts with ts extension",
+			formatName: "mpegts",
+			path:       "/videos/sample.ts",
+			want:       "ts",
+		},
+		{
+			name:       "mpegts with m2ts extension",
+			formatName: "mpegts",
+			path:       "/videos/sample.m2ts",
+			want:       "m2ts",
+		},
+		{
+			name:       "avi keeps extension mapping",
+			formatName: "avi",
+			path:       "/videos/sample.avi",
+			want:       "avi",
+		},
+		{
+			name:       "asf maps to wmv",
+			formatName: "asf",
+			path:       "/videos/sample.wmv",
+			want:       "wmv",
+		},
+		{
+			name:       "fallback to extension when probe fails",
+			formatName: "",
+			path:       "/videos/sample.mp4",
+			want:       "mp4",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := detectContainer(tt.formatName, tt.path); got != tt.want {
+				t.Fatalf("detectContainer(%q, %q) = %q, want %q", tt.formatName, tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestFindFFmpegPathUsesPersistentDataTool(t *testing.T) {
 	originalWorkingDir, err := os.Getwd()
 	if err != nil {

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -3836,6 +3836,7 @@ export default function App() {
         containerMode={containerMode}
         directoryPickerEnabled={directoryPickerEnabled}
         hostPathPrefixEnabled={hostPathPrefixEnabled}
+        hostAgentConfigured={configFlag(config?.host_agent_configured)}
         mpvEnabled={mpvEnabled}
         onCreateDirectory={async (payload) => {
           const created = await createDirectory(payload)

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -255,6 +255,8 @@ export default function App() {
     deleteDirectory,
     enabledDirectoryIds,
     setEnabledDirectoryIds,
+    closedSubdirectories,
+    setClosedSubdirectories,
     directoryFilterMode,
   } = useStore()
 
@@ -998,6 +1000,7 @@ export default function App() {
   const applyUrlState = useCallback(
     (parsed) => {
       useStore.getState().setDirectoryFilterFromUrl(parsed.directoryIds)
+      useStore.getState().setClosedSubdirectoriesFromUrl(parsed.closedSubdirs)
       const mapTagIdsToNamesFromStore = (ids) => {
         if (!Array.isArray(ids) || ids.length === 0) return []
         const { tags: storeTags } = useStore.getState()
@@ -1114,6 +1117,7 @@ export default function App() {
           directories,
           enabledDirectoryIds,
           directoryFilterMode,
+          closedSubdirectories,
         },
         tagsByName
       ),
@@ -1121,6 +1125,7 @@ export default function App() {
       directories,
       directoryFilterMode,
       enabledDirectoryIds,
+      closedSubdirectories,
       idolFavoriteGroupId,
       idolTempSort,
       javFavoriteGroupId,
@@ -3302,6 +3307,8 @@ export default function App() {
         directories={directories}
         enabledDirectoryIds={enabledDirectoryIds}
         onEnabledDirectoryIdsChange={setEnabledDirectoryIds}
+        closedSubdirectories={closedSubdirectories}
+        onClosedSubdirectoriesChange={setClosedSubdirectories}
         hostPathPrefixEnabled={hostPathPrefixEnabled}
         selectedCount={selectedCount}
         onOpenSelectionOps={() => setSelectionOpsOpen(true)}

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -89,12 +89,12 @@ const saveWaterfallModes = (modes) => {
 const JAV_SCRAPE_OVERRIDE_SKIP = ':skip'
 const JAV_SCRAPE_OVERRIDE_MANUAL_PREFIX = ':manual:'
 
-const normalizeDefaultPlayer = (value) => {
+const normalizeDefaultPlayer = (value, mpvEnabled = true) => {
   const normalized = String(value || '')
     .trim()
     .toLowerCase()
   if (normalized === 'browser' || normalized === 'system') return normalized
-  return 'mpv'
+  return mpvEnabled ? 'mpv' : 'browser'
 }
 
 const configFlag = (value, fallback = false) => {
@@ -408,10 +408,16 @@ export default function App() {
   const mpvEnabled = configFlag(config?.mpv_enabled, true)
   const defaultPlayer = browserPlaybackOnly
     ? 'browser'
-    : normalizeDefaultPlayer(config?.default_player)
+    : normalizeDefaultPlayer(config?.default_player, mpvEnabled)
   const initialViewMode = normalizeInitialViewMode(config?.initial_view_mode)
   const showTopBarButtonTooltips = configFlag(config?.show_top_bar_button_tooltips, true)
-  const alternatePlayer = browserPlaybackOnly ? '' : defaultPlayer === 'system' ? 'mpv' : 'system'
+  const alternatePlayer = browserPlaybackOnly
+    ? ''
+    : defaultPlayer === 'system'
+      ? mpvEnabled
+        ? 'mpv'
+        : ''
+      : 'system'
   const alternatePlayerLabel =
     alternatePlayer === 'mpv'
       ? zh('使用MPV播放器播放', 'Play with MPV player')

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -60,6 +60,32 @@ import { withJavTagDisplayName } from '@/utils/javTag'
 import { directoryQueryIds, useStore, videoSelectionKey } from '@/store'
 import { useAuth } from '@/auth'
 
+const WATERFALL_STORAGE_KEY = 'javboss.waterfallModes'
+const WATERFALL_KEYS = ['video', 'jav', 'idol', 'studio', 'series']
+
+const loadSavedWaterfallModes = () => {
+  try {
+    const raw = window.localStorage.getItem(WATERFALL_STORAGE_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw)
+    const result = {}
+    for (const key of WATERFALL_KEYS) {
+      if (typeof parsed[key] === 'boolean') result[key] = parsed[key]
+    }
+    return Object.keys(result).length ? result : null
+  } catch {
+    return null
+  }
+}
+
+const saveWaterfallModes = (modes) => {
+  try {
+    window.localStorage.setItem(WATERFALL_STORAGE_KEY, JSON.stringify(modes))
+  } catch {
+    // 忽略存储失败（如隐私模式）
+  }
+}
+
 const JAV_SCRAPE_OVERRIDE_SKIP = ':skip'
 const JAV_SCRAPE_OVERRIDE_MANUAL_PREFIX = ':manual:'
 
@@ -263,13 +289,14 @@ export default function App() {
   const [scrapeSettingsSaving, setScrapeSettingsSaving] = useState(false)
   const [searchInput, setSearchInput] = useState('')
   const [javSearchInput, setJavSearchInput] = useState('')
-  const [waterfallModes, setWaterfallModes] = useState({
+  const [waterfallModes, setWaterfallModes] = useState(() => ({
     video: false,
     jav: false,
     idol: false,
     studio: false,
     series: false,
-  })
+    ...loadSavedWaterfallModes(),
+  }))
   const [hydrated, setHydrated] = useState(false)
   const [configLoaded, setConfigLoaded] = useState(false)
   const isJavMode = viewMode === 'jav'
@@ -939,13 +966,21 @@ export default function App() {
 
   useEffect(() => {
     if (!configLoaded) return
-    setWaterfallModes((current) => ({
-      ...current,
-      jav: configFlag(config?.jav_waterfall_default),
-      idol: configFlag(config?.idol_waterfall_default),
-      studio: configFlag(config?.studio_waterfall_default),
-      series: configFlag(config?.series_waterfall_default),
-    }))
+    setWaterfallModes((current) => {
+      const saved = loadSavedWaterfallModes()
+      const next = { ...current }
+      const configDefaults = {
+        jav: configFlag(config?.jav_waterfall_default),
+        idol: configFlag(config?.idol_waterfall_default),
+        studio: configFlag(config?.studio_waterfall_default),
+        series: configFlag(config?.series_waterfall_default),
+      }
+      // 已保存的本地偏好优先，未保存过的页面采用配置默认值
+      for (const [key, value] of Object.entries(configDefaults)) {
+        if (!saved || !(key in saved)) next[key] = value
+      }
+      return next
+    })
   }, [
     configLoaded,
     config?.jav_waterfall_default,
@@ -1565,7 +1600,11 @@ export default function App() {
 
   const setWaterfallMode = useCallback(
     (key, enabled) => {
-      setWaterfallModes((current) => ({ ...current, [key]: enabled }))
+      setWaterfallModes((current) => {
+        const next = { ...current, [key]: enabled }
+        saveWaterfallModes(next)
+        return next
+      })
       if (enabled || !hydrated || !configLoaded) return
       if (key === 'video') {
         loadVideos({ force: true })

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -79,6 +79,7 @@ export async function fetchVideos({
   sort = '',
   seed = null,
   directoryIds = [],
+  closedSubdirs = [],
   hideJav = false,
 } = {}) {
   const params = new URLSearchParams()
@@ -89,6 +90,8 @@ export async function fetchVideos({
   if (sort) params.set('sort', sort)
   if (seed != null) params.set('seed', String(seed))
   if (directoryIds.length) params.set('directory_ids', directoryIds.join(','))
+  const closed = closedSubdirsParam(closedSubdirs)
+  if (closed) params.set('closed_subdirs', closed)
   params.set('hide_jav', hideJav ? '1' : '0')
   const res = await apiFetch(`/videos?${params.toString()}`)
   if (!res.ok) throw await apiError(res)
@@ -100,9 +103,11 @@ export async function fetchVideos({
   return data
 }
 
-export async function fetchTags({ directoryIds = [], hideJav = false } = {}) {
+export async function fetchTags({ directoryIds = [], closedSubdirs = [], hideJav = false } = {}) {
   const params = new URLSearchParams()
   if (directoryIds.length) params.set('directory_ids', directoryIds.join(','))
+  const closed = closedSubdirsParam(closedSubdirs)
+  if (closed) params.set('closed_subdirs', closed)
   params.set('hide_jav', hideJav ? '1' : '0')
   const query = params.toString()
   const res = await apiFetch(`/tags${query ? `?${query}` : ''}`)
@@ -407,6 +412,29 @@ export async function fetchDirectories() {
   return res.json()
 }
 
+// Fetches first-level subdirectories (with active video counts) of a root directory.
+// Returns { root_video_count, subdirectories: [{ name, video_count }] }.
+export async function fetchDirectorySubdirectories(directoryId) {
+  const res = await apiFetch(`/directories/${encodeURIComponent(directoryId)}/subdirectories`)
+  if (!res.ok) throw await apiError(res)
+  return res.json()
+}
+
+// Serializes closed subdirectory entries ("directoryId:name" pairs) for the
+// closed_subdirs query parameter.
+const closedSubdirsParam = (closedSubdirs = []) => {
+  if (!Array.isArray(closedSubdirs) || closedSubdirs.length === 0) return ''
+  return closedSubdirs
+    .map((item) => {
+      const id = Number(item?.directoryId)
+      const name = String(item?.name || '').trim()
+      if (!Number.isFinite(id) || id <= 0 || !name) return ''
+      return `${id}:${name}`
+    })
+    .filter(Boolean)
+    .join(',')
+}
+
 export async function createDirectory({ path }) {
   const res = await apiFetch('/directories', {
     method: 'POST',
@@ -470,6 +498,7 @@ export async function fetchJavs({
   sort = '',
   seed = null,
   directoryIds = [],
+  closedSubdirs = [],
   favoriteGroupId = null,
 } = {}) {
   const params = new URLSearchParams()
@@ -485,6 +514,8 @@ export async function fetchJavs({
   if (sort) params.set('sort', sort)
   if (seed != null) params.set('seed', String(seed))
   if (directoryIds.length) params.set('directory_ids', directoryIds.join(','))
+  const closed = closedSubdirsParam(closedSubdirs)
+  if (closed) params.set('closed_subdirs', closed)
   if (favoriteGroupId) params.set('favorite_group_id', String(favoriteGroupId))
   const res = await apiFetch(`/jav?${params.toString()}`)
   if (!res.ok) {
@@ -554,9 +585,11 @@ export async function fetchJavPrefixes({ directoryIds = [] } = {}) {
   return res.json()
 }
 
-export async function fetchJavTags({ directoryIds = [] } = {}) {
+export async function fetchJavTags({ directoryIds = [], closedSubdirs = [] } = {}) {
   const params = new URLSearchParams()
   if (directoryIds.length) params.set('directory_ids', directoryIds.join(','))
+  const closed = closedSubdirsParam(closedSubdirs)
+  if (closed) params.set('closed_subdirs', closed)
   const query = params.toString()
   const res = await apiFetch(`/jav/tags${query ? `?${query}` : ''}`)
   if (!res.ok) {
@@ -672,6 +705,7 @@ export async function fetchJavIdols({
   search = '',
   sort = '',
   directoryIds = [],
+  closedSubdirs = [],
   favoriteGroupId = null,
 } = {}) {
   const params = new URLSearchParams()
@@ -680,6 +714,8 @@ export async function fetchJavIdols({
   if (search) params.set('search', search)
   if (sort) params.set('sort', sort)
   if (directoryIds.length) params.set('directory_ids', directoryIds.join(','))
+  const closed = closedSubdirsParam(closedSubdirs)
+  if (closed) params.set('closed_subdirs', closed)
   if (favoriteGroupId) params.set('favorite_group_id', String(favoriteGroupId))
   const res = await apiFetch(`/jav/idols?${params.toString()}`)
   if (!res.ok) {
@@ -914,6 +950,7 @@ export async function fetchJavStudios({
   offset = 0,
   search = '',
   directoryIds = [],
+  closedSubdirs = [],
   favoriteGroupId = null,
 } = {}) {
   const params = new URLSearchParams()
@@ -921,6 +958,8 @@ export async function fetchJavStudios({
   params.set('offset', String(offset))
   if (search) params.set('search', search)
   if (directoryIds.length) params.set('directory_ids', directoryIds.join(','))
+  const closed = closedSubdirsParam(closedSubdirs)
+  if (closed) params.set('closed_subdirs', closed)
   if (favoriteGroupId) params.set('favorite_group_id', String(favoriteGroupId))
   const res = await apiFetch(`/jav/studios?${params.toString()}`)
   if (!res.ok) {
@@ -1001,6 +1040,7 @@ export async function fetchJavSeries({
   offset = 0,
   search = '',
   directoryIds = [],
+  closedSubdirs = [],
   favoriteGroupId = null,
 } = {}) {
   const params = new URLSearchParams()
@@ -1008,6 +1048,8 @@ export async function fetchJavSeries({
   params.set('offset', String(offset))
   if (search) params.set('search', search)
   if (directoryIds.length) params.set('directory_ids', directoryIds.join(','))
+  const closed = closedSubdirsParam(closedSubdirs)
+  if (closed) params.set('closed_subdirs', closed)
   if (favoriteGroupId) params.set('favorite_group_id', String(favoriteGroupId))
   const res = await apiFetch(`/jav/series?${params.toString()}`)
   if (!res.ok) {

--- a/web/src/components/GlobalSettingsModal.jsx
+++ b/web/src/components/GlobalSettingsModal.jsx
@@ -63,6 +63,7 @@ export default function GlobalSettingsModal({
   containerMode = false,
   directoryPickerEnabled = true,
   hostPathPrefixEnabled = false,
+  hostAgentConfigured = false,
   mpvEnabled = true,
   onCreateDirectory,
   onUpdateDirectory,
@@ -177,7 +178,11 @@ export default function GlobalSettingsModal({
       setAllowLANAccessInput(allowLANAccess === true)
       setAllowLANAccessError('')
       setDefaultPlayerInput(
-        defaultPlayer === 'browser' || defaultPlayer === 'system' ? defaultPlayer : 'mpv'
+        defaultPlayer === 'browser' || defaultPlayer === 'system'
+          ? defaultPlayer
+          : mpvEnabled
+            ? 'mpv'
+            : 'browser'
       )
       setDefaultPlayerError('')
       setInitialViewModeInput(initialViewMode === 'jav' ? 'jav' : 'video')
@@ -386,7 +391,7 @@ export default function GlobalSettingsModal({
                   }}
                   className="w-auto appearance-none rounded-xl border border-zinc-200 bg-white py-1.5 pl-3 pr-7 text-sm text-zinc-800 outline-none focus:border-zinc-200 focus:outline-none focus:ring-0 focus-visible:outline-none"
                 >
-                  <option value="mpv">MPV</option>
+                  {mpvEnabled ? <option value="mpv">MPV</option> : null}
                   <option value="browser">{zh('浏览器', 'Browser')}</option>
                   <option value="system">{zh('系统', 'System')}</option>
                 </select>
@@ -401,6 +406,14 @@ export default function GlobalSettingsModal({
                 {zh(
                   '浏览器默认只能播放 MP4 格式视频，如果需要播放任意格式视频需前往“工具”中确认 FFmpeg 已安装。',
                   'Browsers can only play MP4 videos by default. To play videos in any format, go to Tools and make sure FFmpeg is installed.'
+                )}
+              </p>
+            ) : null}
+            {containerMode && hostAgentConfigured ? (
+              <p className="mt-1 text-sm text-zinc-500">
+                {zh(
+                  '选择“系统”将通过宿主机代理在部署主机上调用系统播放器打开视频。',
+                  'Choosing “System” opens the video with the host machine’s default player via the host agent.'
                 )}
               </p>
             ) : null}

--- a/web/src/components/PlayerModal.jsx
+++ b/web/src/components/PlayerModal.jsx
@@ -25,10 +25,18 @@ export default function PlayerModal({
   const hotkeyMapRef = useRef(new Map())
   const screenshotInFlightRef = useRef(false)
   const screenshotNoticeTimerRef = useRef(null)
+  // App 侧传入的 onClose / onPlaybackError 通常是内联箭头函数，每次渲染引用都会变。
+  // 若直接作为 effect 依赖，会导致播放器反复 dispose/重建（video.js 会移除 DOM，
+  // 重建时拿到已脱离文档的元素而失败，播放区变黑），因此用 ref 保存最新回调。
+  const onCloseRef = useRef(onClose)
+  onCloseRef.current = onClose
+  const onPlaybackErrorRef = useRef(onPlaybackError)
+  onPlaybackErrorRef.current = onPlaybackError
   const [playbackInfo, setPlaybackInfo] = useState(null)
   const [playbackError, setPlaybackError] = useState('')
   const [loadingPlayback, setLoadingPlayback] = useState(false)
   const [screenshotNotice, setScreenshotNotice] = useState(false)
+  const [videoSize, setVideoSize] = useState(null) // { width, height } of the source video
   const normalizedHotkeys = useMemo(() => parsePlayerHotkeys(hotkeys), [hotkeys])
   const selectedSource = useMemo(() => {
     if (!playbackInfo?.sources?.length) return null
@@ -56,6 +64,7 @@ export default function PlayerModal({
       setPlaybackError('')
       setLoadingPlayback(false)
       setScreenshotNotice(false)
+      setVideoSize(null)
       return
     }
 
@@ -64,6 +73,7 @@ export default function PlayerModal({
     setPlaybackError('')
     setPlaybackInfo(null)
     setScreenshotNotice(false)
+    setVideoSize(null)
 
     fetchPlaybackInfo(video.id, { locationId: video.location_id })
       .then((info) => {
@@ -74,7 +84,7 @@ export default function PlayerModal({
         if (cancelled) return
         const message = getErrorMessage(err)
         setPlaybackError(message)
-        onPlaybackError?.(message)
+        onPlaybackErrorRef.current?.(message)
       })
       .finally(() => {
         if (cancelled) return
@@ -84,7 +94,7 @@ export default function PlayerModal({
     return () => {
       cancelled = true
     }
-  }, [onPlaybackError, video])
+  }, [video])
 
   useEffect(() => {
     if (!video || !videoRef.current || !selectedSource?.src) return
@@ -204,7 +214,7 @@ export default function PlayerModal({
         }
         case 'Escape':
           markHandled()
-          onClose()
+          onCloseRef.current()
           break
         default:
           return
@@ -213,6 +223,16 @@ export default function PlayerModal({
 
     const focusPlayer = () => {
       playerEl?.focus({ preventScroll: true })
+    }
+    // video.js 在 data-vjs-player 包装下会用新的 .vjs-tech 元素替换原 <video> 标签，
+    // 因此不能从 videoRef.current 读尺寸（恒为 0），必须走 player API。
+    // 同时监听 resize：HLS 等流在 loadedmetadata 时可能还拿不到分辨率，稍后会再触发。
+    const handleDimensions = () => {
+      const width = player.videoWidth()
+      const height = player.videoHeight()
+      if (width > 0 && height > 0) {
+        setVideoSize({ width, height })
+      }
     }
     const applyStartTime = () => {
       const nextStartTime = Number(startTime)
@@ -240,46 +260,68 @@ export default function PlayerModal({
     })
     player.on('fullscreenchange', focusPlayer)
     player.on('volumechange', handleVolumeChange)
+    player.on('loadedmetadata', handleDimensions)
+    player.on('resize', handleDimensions)
 
     return () => {
       window.removeEventListener('keydown', handleKeyDown, true)
       player.off('fullscreenchange', focusPlayer)
       player.off('volumechange', handleVolumeChange)
+      player.off('loadedmetadata', handleDimensions)
+      player.off('resize', handleDimensions)
       playerRef.current?.dispose()
       playerRef.current = null
     }
-  }, [video, startTime, onClose, selectedSource])
+  }, [video, startTime, selectedSource])
 
   if (!video) return null
 
   const displayName = getVideoDisplayName(video)
+  const aspectRatio =
+    videoSize && videoSize.height > 0 ? videoSize.width / videoSize.height : 16 / 9
 
   return (
-    <div className="fixed inset-0 z-[1700] flex items-center justify-center bg-black/70">
-      <div className="relative mx-4 w-full max-w-6xl rounded-lg bg-white shadow-lg">
+    <div className="fixed inset-0 z-[1700] flex items-center justify-center bg-black/70 pointer-coarse:bg-black">
+      {/*
+        桌面端：白色卡片包裹，标题与关闭按钮在卡片内；
+        移动端（触摸设备，含横屏）：隐藏白卡片边框，视频按比例贴边（100vw/100dvh，不超出不拉伸），标题悬浮在视频上方。
+        宽度公式在 .player-card 的媒体查询中，比例通过 --player-ar 传入。
+      */}
+      <div
+        className="player-card relative mx-4 rounded-lg bg-white shadow-lg pointer-coarse:mx-0 pointer-coarse:rounded-none pointer-coarse:bg-black pointer-coarse:shadow-none"
+        style={{ '--player-ar': `${aspectRatio}` }}
+      >
         <button
           aria-label={zh('关闭', 'Close')}
           onClick={onClose}
-          className="absolute right-3 top-3 rounded-full bg-black/60 px-2 py-1 text-sm text-white hover:bg-black/80"
+          className="absolute right-3 top-3 z-20 rounded-full bg-black/60 px-2 py-1 text-sm text-white hover:bg-black/80"
         >
           ×
         </button>
-        <div className="flex flex-col gap-4 p-4">
-          <h2 className="truncate text-lg font-semibold" title={displayName}>
+        <div className="flex flex-col gap-4 p-4 pointer-coarse:gap-0 pointer-coarse:p-0">
+          <h2
+            className="truncate pr-10 text-lg font-semibold pointer-coarse:absolute pointer-coarse:inset-x-0 pointer-coarse:top-0 pointer-coarse:z-10 pointer-coarse:bg-gradient-to-b pointer-coarse:from-black/60 pointer-coarse:to-transparent pointer-coarse:px-12 pointer-coarse:pb-5 pointer-coarse:pt-2 pointer-coarse:text-sm pointer-coarse:font-medium pointer-coarse:text-white"
+            title={displayName}
+          >
             {displayName}
           </h2>
-          <div className="player-shell relative w-full bg-black">
+          <div
+            className="player-shell relative w-full bg-black"
+            style={{
+              aspectRatio: videoSize ? `${videoSize.width} / ${videoSize.height}` : '16 / 9',
+            }}
+          >
             {screenshotNotice ? (
               <div className="pointer-events-none absolute left-3 top-3 z-10 rounded bg-black/75 px-3 py-1.5 text-sm font-medium text-white shadow">
                 {zh('截图成功', 'Screenshot saved')}
               </div>
             ) : null}
             {loadingPlayback ? (
-              <div className="flex aspect-video items-center justify-center text-sm text-white">
+              <div className="flex h-full w-full items-center justify-center text-sm text-white">
                 {zh('加载播放信息中…', 'Loading playback info...')}
               </div>
             ) : playbackError ? (
-              <div className="flex aspect-video items-center justify-center px-6 text-center text-sm text-red-200">
+              <div className="flex h-full w-full items-center justify-center px-6 text-center text-sm text-red-200">
                 {playbackError}
               </div>
             ) : (

--- a/web/src/components/PlayerModal.jsx
+++ b/web/src/components/PlayerModal.jsx
@@ -69,6 +69,32 @@ export default function PlayerModal({
   const menuOpenRef = useRef(null)
   const screenshotInFlightRef = useRef(false)
   const screenshotNoticeTimerRef = useRef(null)
+  const pendingSeekTimerRef = useRef(null)
+
+  // 乐观 seek：设置播放器时间后立即更新 UI，并启动兑底定时器——若 5 秒内
+  // 仍未定位完成（HLS 转码流定位慢），回落到播放器真实时间，避免永久卡住。
+  // 注意：必须在所有 useEffect 之前定义（播放器 effect 的依赖数组会引用它，
+  // 否则 const 处于暂时性死区，组件初始化即崩溃）。
+  const applySeek = useCallback((time) => {
+    const player = playerRef.current
+    if (!player) return
+    let next = Number(time) || 0
+    const durationVal = player.duration()
+    if (Number.isFinite(durationVal)) {
+      next = Math.min(Math.max(0, next), durationVal)
+    } else {
+      next = Math.max(0, next)
+    }
+    player.currentTime(next)
+    setPendingSeekTime(next)
+    if (pendingSeekTimerRef.current) {
+      window.clearTimeout(pendingSeekTimerRef.current)
+    }
+    pendingSeekTimerRef.current = window.setTimeout(() => {
+      pendingSeekTimerRef.current = null
+      setPendingSeekTime(null)
+    }, 5000)
+  }, [])
   const actionsRef = useRef(null)
   // App 侧传入的 onClose / onPlaybackError 通常是内联箭头函数，每次渲染引用都会变。
   // 若直接作为 effect 依赖，会导致播放器反复 dispose/重建（video.js 会移除 DOM，
@@ -95,6 +121,9 @@ export default function PlayerModal({
   const [menuOpen, setMenuOpen] = useState(null) // null | 'speed'
   const [seekHoverTime, setSeekHoverTime] = useState(null)
   const [dragTime, setDragTime] = useState(null)
+  // 乐观 seek：点击进度条后立即把 UI 钉在目标位置，避免 HLS 等流定位期间
+  // 进度条先退回旧位置再跳过去的视觉抖动；定位完成（seeked/追平）后清除。
+  const [pendingSeekTime, setPendingSeekTime] = useState(null)
   const [isFullscreen, setIsFullscreen] = useState(false)
   // 精细指针（鼠标）设备：有“移出播放区域”概念，用于移出即隐藏控制条
   const [isFinePointer] = useState(
@@ -129,6 +158,9 @@ export default function PlayerModal({
     return () => {
       if (screenshotNoticeTimerRef.current) {
         window.clearTimeout(screenshotNoticeTimerRef.current)
+      }
+      if (pendingSeekTimerRef.current) {
+        window.clearTimeout(pendingSeekTimerRef.current)
       }
       if (hideTimerRef.current) {
         window.clearTimeout(hideTimerRef.current)
@@ -393,14 +425,7 @@ export default function PlayerModal({
     // ---- 控制条动作 ----
     const seekBy = (offsetSeconds) => {
       const current = player.currentTime() || 0
-      const durationVal = player.duration()
-      let next = current + offsetSeconds
-      if (Number.isFinite(durationVal)) {
-        next = Math.min(Math.max(0, next), durationVal)
-      } else {
-        next = Math.max(0, next)
-      }
-      player.currentTime(next)
+      applySeek(current + offsetSeconds)
     }
 
     const adjustVolume = (delta) => {
@@ -496,6 +521,7 @@ export default function PlayerModal({
       setPlaying(false)
       setEnded(true)
       setWaiting(false)
+      setPendingSeekTime(null)
     }
     const handleWaiting = () => setWaiting(true)
     const handleCanPlay = () => setWaiting(false)
@@ -577,7 +603,7 @@ export default function PlayerModal({
     const applyStartTime = () => {
       const nextStartTime = Number(startTime)
       if (!Number.isFinite(nextStartTime) || nextStartTime <= 0) return
-      player.currentTime(nextStartTime)
+      applySeek(nextStartTime)
     }
 
     if (playerEl && !playerEl.hasAttribute('tabindex')) {
@@ -610,8 +636,25 @@ export default function PlayerModal({
     player.on('waiting', handleWaiting)
     player.on('playing', handleCanPlay)
     player.on('canplay', handleCanPlay)
-    player.on('timeupdate', syncTime)
-    player.on('seeked', syncTime)
+    const handleTimeUpdate = () => {
+      syncTime()
+      // 播放器时间追平目标位置后清除乐观状态，让 UI 跟随真实播放位置
+      setPendingSeekTime((pending) => {
+        if (pending == null) return null
+        const current = player.currentTime() || 0
+        return Math.abs(current - pending) < 1 ? null : pending
+      })
+    }
+    const handleSeeked = () => {
+      syncTime()
+      if (pendingSeekTimerRef.current) {
+        window.clearTimeout(pendingSeekTimerRef.current)
+        pendingSeekTimerRef.current = null
+      }
+      setPendingSeekTime(null)
+    }
+    player.on('timeupdate', handleTimeUpdate)
+    player.on('seeked', handleSeeked)
     player.on('durationchange', syncDuration)
     player.on('progress', syncBuffered)
     player.on('loadedmetadata', handleLoadedMetadata)
@@ -629,8 +672,8 @@ export default function PlayerModal({
       player.off('waiting', handleWaiting)
       player.off('playing', handleCanPlay)
       player.off('canplay', handleCanPlay)
-      player.off('timeupdate', syncTime)
-      player.off('seeked', syncTime)
+      player.off('timeupdate', handleTimeUpdate)
+      player.off('seeked', handleSeeked)
       player.off('durationchange', syncDuration)
       player.off('progress', syncBuffered)
       player.off('loadedmetadata', handleLoadedMetadata)
@@ -639,10 +682,11 @@ export default function PlayerModal({
       player.off('ratechange', handleRateChange)
       player.off('fullscreenchange', focusPlayer)
       player.off('resize', handleDimensions)
+      setPendingSeekTime(null)
       playerRef.current?.dispose()
       playerRef.current = null
     }
-  }, [video, startTime, selectedSource, pokeControls])
+  }, [video, startTime, selectedSource, pokeControls, applySeek])
 
   // ---- 进度条交互 ----
   const seekTimeFromEvent = (event) => {
@@ -683,7 +727,7 @@ export default function PlayerModal({
     const time = dragTime ?? seekTimeFromEvent(event)
     setDragTime(null)
     setSeekHoverTime(null)
-    playerRef.current?.currentTime(time)
+    applySeek(time)
     try {
       seekBarRef.current?.releasePointerCapture?.(event.pointerId)
     } catch {
@@ -705,7 +749,7 @@ export default function PlayerModal({
     }
     if (next == null) return
     event.preventDefault()
-    playerRef.current?.currentTime(Math.min(Math.max(0, next), duration))
+    applySeek(Math.min(Math.max(0, next), duration))
   }
 
   if (!video) return null
@@ -713,7 +757,7 @@ export default function PlayerModal({
   const displayName = getVideoDisplayName(video)
   const aspectRatio =
     videoSize && videoSize.height > 0 ? videoSize.width / videoSize.height : 16 / 9
-  const displayTime = dragTime ?? currentTime
+  const displayTime = dragTime ?? pendingSeekTime ?? currentTime
   const playedPercent = duration > 0 ? clampPercent((displayTime / duration) * 100) : 0
   const bufferedPercent = duration > 0 ? clampPercent((bufferedEnd / duration) * 100) : 0
   const tooltipTime = dragTime ?? seekHoverTime

--- a/web/src/components/PlayerModal.jsx
+++ b/web/src/components/PlayerModal.jsx
@@ -1,10 +1,24 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import videojs from 'video.js'
 import 'video.js/dist/video-js.css'
+import CheckIcon from '@mui/icons-material/Check'
+import Forward10Icon from '@mui/icons-material/Forward10'
+import FullscreenExitIcon from '@mui/icons-material/FullscreenExit'
+import FullscreenIcon from '@mui/icons-material/Fullscreen'
+import PauseIcon from '@mui/icons-material/Pause'
+import PhotoCameraIcon from '@mui/icons-material/PhotoCamera'
+import PlayArrowIcon from '@mui/icons-material/PlayArrow'
+import Replay10Icon from '@mui/icons-material/Replay10'
+import ReplayIcon from '@mui/icons-material/Replay'
+import SettingsIcon from '@mui/icons-material/Settings'
+import VolumeDownIcon from '@mui/icons-material/VolumeDown'
+import VolumeOffIcon from '@mui/icons-material/VolumeOff'
+import VolumeUpIcon from '@mui/icons-material/VolumeUp'
 import { createVideoScreenshot, fetchPlaybackInfo } from '@/api'
 import { getVideoDisplayName } from '@/utils/display'
 import {
   PLAYER_HOTKEY_ACTIONS,
+  formatPlayerHotkeyKey,
   normalizePlayerHotkeyKey,
   parsePlayerHotkeys,
 } from '@/utils/playerHotkeys'
@@ -12,6 +26,30 @@ import { zh } from '@/utils/i18n'
 import { getErrorMessage } from '@/utils/errors'
 
 const VOLUME_STORAGE_KEY = 'javboss.player.volume'
+const CONTROLS_HIDE_DELAY_MS = 3000
+const SEEK_STEP_SECONDS = 10
+const PLAYBACK_RATES = [0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2]
+
+function formatTime(seconds) {
+  if (!Number.isFinite(seconds) || seconds < 0) seconds = 0
+  const total = Math.floor(seconds)
+  const hours = Math.floor(total / 3600)
+  const minutes = Math.floor((total % 3600) / 60)
+  const secs = total % 60
+  const paddedMinutes = hours > 0 ? String(minutes).padStart(2, '0') : String(minutes)
+  const paddedSeconds = String(secs).padStart(2, '0')
+  return hours > 0
+    ? `${hours}:${paddedMinutes}:${paddedSeconds}`
+    : `${paddedMinutes}:${paddedSeconds}`
+}
+
+function clampPercent(value) {
+  if (!Number.isFinite(value)) return 0
+  return Math.min(100, Math.max(0, value))
+}
+
+const iconButtonClass =
+  'flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-white transition-colors hover:bg-white/15 pointer-coarse:h-8 pointer-coarse:w-8'
 
 export default function PlayerModal({
   video,
@@ -22,9 +60,16 @@ export default function PlayerModal({
 }) {
   const videoRef = useRef(null)
   const playerRef = useRef(null)
+  const shellRef = useRef(null)
+  const seekBarRef = useRef(null)
   const hotkeyMapRef = useRef(new Map())
+  const hideTimerRef = useRef(null)
+  const clickTimerRef = useRef(null)
+  const dragRef = useRef({ active: false })
+  const menuOpenRef = useRef(null)
   const screenshotInFlightRef = useRef(false)
   const screenshotNoticeTimerRef = useRef(null)
+  const actionsRef = useRef(null)
   // App 侧传入的 onClose / onPlaybackError 通常是内联箭头函数，每次渲染引用都会变。
   // 若直接作为 effect 依赖，会导致播放器反复 dispose/重建（video.js 会移除 DOM，
   // 重建时拿到已脱离文档的元素而失败，播放区变黑），因此用 ref 保存最新回调。
@@ -37,7 +82,33 @@ export default function PlayerModal({
   const [loadingPlayback, setLoadingPlayback] = useState(false)
   const [screenshotNotice, setScreenshotNotice] = useState(false)
   const [videoSize, setVideoSize] = useState(null) // { width, height } of the source video
+  const [playing, setPlaying] = useState(false)
+  const [waiting, setWaiting] = useState(false)
+  const [ended, setEnded] = useState(false)
+  const [currentTime, setCurrentTime] = useState(0)
+  const [duration, setDuration] = useState(0)
+  const [bufferedEnd, setBufferedEnd] = useState(0)
+  const [volume, setVolume] = useState(1)
+  const [muted, setMuted] = useState(false)
+  const [playbackRate, setPlaybackRate] = useState(1)
+  const [controlsVisible, setControlsVisible] = useState(true)
+  const [menuOpen, setMenuOpen] = useState(null) // null | 'speed'
+  const [seekHoverTime, setSeekHoverTime] = useState(null)
+  const [dragTime, setDragTime] = useState(null)
+  const [isFullscreen, setIsFullscreen] = useState(false)
+  // 精细指针（鼠标）设备：有“移出播放区域”概念，用于移出即隐藏控制条
+  const [isFinePointer] = useState(
+    () =>
+      typeof window !== 'undefined' &&
+      window.matchMedia('(hover: hover) and (pointer: fine)').matches
+  )
   const normalizedHotkeys = useMemo(() => parsePlayerHotkeys(hotkeys), [hotkeys])
+  const screenshotHotkeyLabel = useMemo(() => {
+    const item = normalizedHotkeys.find(
+      (entry) => entry.action === PLAYER_HOTKEY_ACTIONS.SCREENSHOT
+    )
+    return item ? formatPlayerHotkeyKey(item.key) : ''
+  }, [normalizedHotkeys])
   const selectedSource = useMemo(() => {
     if (!playbackInfo?.sources?.length) return null
     return (
@@ -51,12 +122,184 @@ export default function PlayerModal({
   }, [normalizedHotkeys])
 
   useEffect(() => {
+    menuOpenRef.current = menuOpen
+  }, [menuOpen])
+
+  useEffect(() => {
     return () => {
       if (screenshotNoticeTimerRef.current) {
         window.clearTimeout(screenshotNoticeTimerRef.current)
       }
+      if (hideTimerRef.current) {
+        window.clearTimeout(hideTimerRef.current)
+      }
+      if (clickTimerRef.current) {
+        window.clearTimeout(clickTimerRef.current)
+      }
     }
   }, [])
+
+  // 全屏状态跟随浏览器全屏（我们对 .player-shell 发起全屏，让自定义控制条保持可见）
+  useEffect(() => {
+    const sync = () =>
+      setIsFullscreen(Boolean(document.fullscreenElement || document.webkitFullscreenElement))
+    document.addEventListener('fullscreenchange', sync)
+    document.addEventListener('webkitfullscreenchange', sync)
+    return () => {
+      document.removeEventListener('fullscreenchange', sync)
+      document.removeEventListener('webkitfullscreenchange', sync)
+    }
+  }, [])
+
+  const showControls = useCallback(() => {
+    setControlsVisible(true)
+    if (hideTimerRef.current) {
+      window.clearTimeout(hideTimerRef.current)
+      hideTimerRef.current = null
+    }
+  }, [])
+
+  const scheduleHideControls = useCallback(() => {
+    if (hideTimerRef.current) {
+      window.clearTimeout(hideTimerRef.current)
+    }
+    hideTimerRef.current = window.setTimeout(() => {
+      hideTimerRef.current = null
+      if (dragRef.current.active || menuOpenRef.current) {
+        return
+      }
+      setControlsVisible(false)
+      setMenuOpen(null)
+    }, CONTROLS_HIDE_DELAY_MS)
+  }, [])
+
+  const pokeControls = useCallback(() => {
+    showControls()
+    scheduleHideControls()
+  }, [showControls, scheduleHideControls])
+
+  // 视频区交互（移动/点击唤出控制条、移出隐藏、单击播放暂停、双击全屏）。
+  // 用原生事件挂在 shell 上而不是 JSX 属性，避免 eslint 对非交互元素的告警。
+  // 注意：PlayerModal 在 App 中始终挂载（video 为 null 时返回 null），本 effect
+  // 首次运行时 shell 尚未挂载；必须以 video 为依赖，在播放器真正打开（shell 挂载）
+  // 后再绑定，否则监听器永远不会挂上（控制条不再响应移动/点击）。
+  useEffect(() => {
+    if (!video) return undefined
+    const shell = shellRef.current
+    if (!shell) return undefined
+
+    const isExcludedTarget = (event) =>
+      event.target instanceof Element &&
+      Boolean(event.target.closest('button, input, [role="slider"], .player-controls'))
+
+    // 记录指针是否曾在 shell 内移动过：shell 在 videoSize 加载后会改变尺寸
+    // （如竖屏视频从 16:9 变 9:16），若指针静止，浏览器也会因几何变化触发
+    // mouseleave —— 这种“假移出”不应隐藏控制条。只有指针真的移动出播放区域才隐藏。
+    let pointerMovedInside = false
+
+    const handleMouseMove = () => {
+      pointerMovedInside = true
+      pokeControls()
+    }
+
+    const handleMouseEnter = () => {
+      pointerMovedInside = false
+    }
+
+    // 光标移出播放区域：立即隐藏控制条（桌面设备；触摸设备无移出概念）
+    const handleMouseLeave = () => {
+      if (!isFinePointer) return
+      if (!pointerMovedInside) return
+      if (hideTimerRef.current) {
+        window.clearTimeout(hideTimerRef.current)
+        hideTimerRef.current = null
+      }
+      setControlsVisible(false)
+      setMenuOpen(null)
+    }
+
+    // 触摸设备：浏览器（Chrome Android 等）不会在 <video> 媒体元素上派发
+    // 兼容鼠标事件（无 click/dblclick），因此“点击切换播放/暂停”必须监听
+    // touchend 实现。同时记录按下位置，滑动（滚动/拖拽）手势不视为点击。
+    let touchStartPos = null
+    let lastTouchEndAt = 0
+
+    const handleTouchStart = (event) => {
+      const touch = event.touches && event.touches[0]
+      touchStartPos = touch ? { x: touch.clientX, y: touch.clientY } : null
+      pokeControls()
+    }
+
+    const handleTouchEnd = (event) => {
+      const start = touchStartPos
+      touchStartPos = null
+      if (!start) return
+      if (isExcludedTarget(event)) return
+      const touch = event.changedTouches && event.changedTouches[0]
+      if (!touch) return
+      const dx = touch.clientX - start.x
+      const dy = touch.clientY - start.y
+      if (dx * dx + dy * dy > 100) return // 位移超过 10px：视为滑动，不是点击
+      lastTouchEndAt = Date.now()
+      pokeControls()
+      actionsRef.current?.togglePlay()
+    }
+
+    // 点击：每次点击都立即唤出控制条并重新计时；
+    // 250ms 内的多次点击合并为一次播放切换（区分双击全屏，避免连点被吞）
+    const handleClick = (event) => {
+      if (isExcludedTarget(event)) return
+      // 触摸 tap 已由 handleTouchEnd 处理；若浏览器（如某些 WebView）在
+      // <video> 上仍派发了 click，避免同一 tap 重复切换
+      if (Date.now() - lastTouchEndAt < 500) return
+      pokeControls()
+      if (clickTimerRef.current) return
+      clickTimerRef.current = window.setTimeout(() => {
+        clickTimerRef.current = null
+        actionsRef.current?.togglePlay()
+      }, 250)
+    }
+
+    const handleDblClick = (event) => {
+      if (isExcludedTarget(event)) return
+      if (Date.now() - lastTouchEndAt < 500) return
+      if (clickTimerRef.current) {
+        window.clearTimeout(clickTimerRef.current)
+        clickTimerRef.current = null
+      }
+      actionsRef.current?.toggleFullscreen()
+    }
+
+    shell.addEventListener('mousemove', handleMouseMove)
+    shell.addEventListener('mouseenter', handleMouseEnter)
+    shell.addEventListener('mouseleave', handleMouseLeave)
+    shell.addEventListener('touchstart', handleTouchStart, { passive: true })
+    shell.addEventListener('touchend', handleTouchEnd, { passive: true })
+    shell.addEventListener('click', handleClick)
+    shell.addEventListener('dblclick', handleDblClick)
+
+    return () => {
+      shell.removeEventListener('mousemove', handleMouseMove)
+      shell.removeEventListener('mouseenter', handleMouseEnter)
+      shell.removeEventListener('mouseleave', handleMouseLeave)
+      shell.removeEventListener('touchstart', handleTouchStart)
+      shell.removeEventListener('touchend', handleTouchEnd)
+      shell.removeEventListener('click', handleClick)
+      shell.removeEventListener('dblclick', handleDblClick)
+      if (clickTimerRef.current) {
+        window.clearTimeout(clickTimerRef.current)
+        clickTimerRef.current = null
+      }
+    }
+  }, [pokeControls, isFinePointer, video])
+
+  // 打开播放器时：控制条默认显示，3 秒无操作后自动隐藏。
+  // 同样以 video 为依赖：挂载时 video 为 null（弹窗未渲染），若只在挂载时 poke，
+  // 定时器会在弹窗打开前就耗尽，导致打开后控制条直接处于隐藏状态。
+  useEffect(() => {
+    if (!video) return undefined
+    pokeControls()
+  }, [pokeControls, video])
 
   useEffect(() => {
     if (!video?.id) {
@@ -100,9 +343,10 @@ export default function PlayerModal({
     if (!video || !videoRef.current || !selectedSource?.src) return
 
     const player = videojs(videoRef.current, {
-      controls: true,
+      controls: false, // 使用自绘 YouTube 风格控制条
       autoplay: true,
       preload: 'auto',
+      bigPlayButton: false,
       sources: [
         {
           src: selectedSource.src,
@@ -129,12 +373,30 @@ export default function PlayerModal({
       player.volume(Math.min(1, Math.max(0, savedVolume)))
     }
 
+    // ---- 状态同步 ----
+    const syncTime = () => setCurrentTime(player.currentTime() || 0)
+    const syncDuration = () =>
+      setDuration(Number.isFinite(player.duration()) ? player.duration() : 0)
+    const syncBuffered = () => {
+      try {
+        const buffered = player.buffered()
+        setBufferedEnd(buffered && buffered.length > 0 ? buffered.end(buffered.length - 1) : 0)
+      } catch {
+        setBufferedEnd(0)
+      }
+    }
+    const syncVolumeState = () => {
+      setVolume(player.volume())
+      setMuted(player.muted())
+    }
+
+    // ---- 控制条动作 ----
     const seekBy = (offsetSeconds) => {
       const current = player.currentTime() || 0
-      const duration = player.duration()
+      const durationVal = player.duration()
       let next = current + offsetSeconds
-      if (Number.isFinite(duration)) {
-        next = Math.min(Math.max(0, next), duration)
+      if (Number.isFinite(durationVal)) {
+        next = Math.min(Math.max(0, next), durationVal)
       } else {
         next = Math.max(0, next)
       }
@@ -142,9 +404,11 @@ export default function PlayerModal({
     }
 
     const adjustVolume = (delta) => {
-      const current = player.volume()
-      const next = Math.min(1, Math.max(0, current + delta))
+      const next = Math.min(1, Math.max(0, player.volume() + delta))
       player.volume(next)
+      if (next > 0 && player.muted()) {
+        player.muted(false)
+      }
     }
 
     const captureScreenshot = () => {
@@ -170,12 +434,83 @@ export default function PlayerModal({
         })
     }
 
+    const toggleFullscreen = () => {
+      const element = shellRef.current
+      if (!element) return
+      if (document.fullscreenElement) {
+        if (document.exitFullscreen) {
+          document.exitFullscreen().catch(() => {})
+        } else if (document.webkitExitFullscreen) {
+          document.webkitExitFullscreen()
+        }
+        return
+      }
+      if (element.requestFullscreen) {
+        element.requestFullscreen().catch(() => {})
+      } else if (element.webkitRequestFullscreen) {
+        element.webkitRequestFullscreen()
+      }
+    }
+
+    actionsRef.current = {
+      togglePlay: () => {
+        if (player.ended()) {
+          player.currentTime(0)
+          player.play()
+          return
+        }
+        if (player.paused()) {
+          player.play()
+        } else {
+          player.pause()
+        }
+      },
+      seekBy,
+      captureScreenshot,
+      setRate: (rate) => {
+        player.playbackRate(rate)
+      },
+      toggleMute: () => {
+        player.muted(!player.muted())
+      },
+      setVolumeLevel: (value) => {
+        const next = Math.min(1, Math.max(0, Number(value)))
+        player.volume(next)
+        if (next > 0 && player.muted()) {
+          player.muted(false)
+        }
+      },
+      toggleFullscreen,
+    }
+
+    // ---- 播放器事件（显隐完全由 pokeControls / 定时器 / 移出驱动，这里只同步状态） ----
+    const handlePlay = () => {
+      setPlaying(true)
+      setEnded(false)
+      setWaiting(false)
+    }
+    const handlePause = () => {
+      setPlaying(false)
+    }
+    const handleEnded = () => {
+      setPlaying(false)
+      setEnded(true)
+      setWaiting(false)
+    }
+    const handleWaiting = () => setWaiting(true)
+    const handleCanPlay = () => setWaiting(false)
+    const handleLoadedMetadata = () => {
+      syncDuration()
+      syncBuffered()
+      handleDimensions()
+    }
+
     const handleKeyDown = (event) => {
       const target = event.target
       if (
         target instanceof Element &&
         (target.isContentEditable ||
-          target.closest('input, textarea, select, [contenteditable="true"]'))
+          target.closest('input, textarea, select, button, [contenteditable="true"]'))
       ) {
         return
       }
@@ -193,10 +528,13 @@ export default function PlayerModal({
       ) {
         markHandled()
         if (configured.action === PLAYER_HOTKEY_ACTIONS.SEEK) {
+          pokeControls()
           seekBy(configured.amount)
         } else if (configured.action === PLAYER_HOTKEY_ACTIONS.VOLUME) {
+          pokeControls()
           adjustVolume(configured.amount / 100)
         } else if (configured.action === PLAYER_HOTKEY_ACTIONS.SCREENSHOT) {
+          pokeControls()
           captureScreenshot()
         }
         return
@@ -213,6 +551,8 @@ export default function PlayerModal({
           break
         }
         case 'Escape':
+          // 浏览器全屏时按 Esc 由浏览器接管退出全屏，不关闭弹窗
+          if (document.fullscreenElement) return
           markHandled()
           onCloseRef.current()
           break
@@ -254,31 +594,131 @@ export default function PlayerModal({
       }
     }
 
+    const handleRateChange = () => setPlaybackRate(player.playbackRate())
+
     player.ready(() => {
       applyStartTime()
+      syncTime()
+      syncDuration()
+      syncBuffered()
+      syncVolumeState()
       focusPlayer()
     })
-    player.on('fullscreenchange', focusPlayer)
+    player.on('play', handlePlay)
+    player.on('pause', handlePause)
+    player.on('ended', handleEnded)
+    player.on('waiting', handleWaiting)
+    player.on('playing', handleCanPlay)
+    player.on('canplay', handleCanPlay)
+    player.on('timeupdate', syncTime)
+    player.on('seeked', syncTime)
+    player.on('durationchange', syncDuration)
+    player.on('progress', syncBuffered)
+    player.on('loadedmetadata', handleLoadedMetadata)
+    player.on('volumechange', syncVolumeState)
     player.on('volumechange', handleVolumeChange)
-    player.on('loadedmetadata', handleDimensions)
+    player.on('ratechange', handleRateChange)
+    player.on('fullscreenchange', focusPlayer)
     player.on('resize', handleDimensions)
 
     return () => {
       window.removeEventListener('keydown', handleKeyDown, true)
-      player.off('fullscreenchange', focusPlayer)
+      player.off('play', handlePlay)
+      player.off('pause', handlePause)
+      player.off('ended', handleEnded)
+      player.off('waiting', handleWaiting)
+      player.off('playing', handleCanPlay)
+      player.off('canplay', handleCanPlay)
+      player.off('timeupdate', syncTime)
+      player.off('seeked', syncTime)
+      player.off('durationchange', syncDuration)
+      player.off('progress', syncBuffered)
+      player.off('loadedmetadata', handleLoadedMetadata)
+      player.off('volumechange', syncVolumeState)
       player.off('volumechange', handleVolumeChange)
-      player.off('loadedmetadata', handleDimensions)
+      player.off('ratechange', handleRateChange)
+      player.off('fullscreenchange', focusPlayer)
       player.off('resize', handleDimensions)
       playerRef.current?.dispose()
       playerRef.current = null
     }
-  }, [video, startTime, selectedSource])
+  }, [video, startTime, selectedSource, pokeControls])
+
+  // ---- 进度条交互 ----
+  const seekTimeFromEvent = (event) => {
+    const bar = seekBarRef.current
+    if (!bar || !duration) return 0
+    const rect = bar.getBoundingClientRect()
+    const ratio = rect.width > 0 ? (event.clientX - rect.left) / rect.width : 0
+    return Math.min(1, Math.max(0, ratio)) * duration
+  }
+
+  const handleSeekPointerDown = (event) => {
+    if (!duration) return
+    dragRef.current.active = true
+    setDragTime(seekTimeFromEvent(event))
+    setSeekHoverTime(null)
+    showControls()
+    try {
+      seekBarRef.current?.setPointerCapture?.(event.pointerId)
+    } catch {
+      // 忽略捕获失败
+    }
+    event.preventDefault()
+  }
+
+  const handleSeekPointerMove = (event) => {
+    if (!duration) return
+    const time = seekTimeFromEvent(event)
+    if (dragRef.current.active) {
+      setDragTime(time)
+    } else {
+      setSeekHoverTime(time)
+    }
+  }
+
+  const handleSeekPointerUp = (event) => {
+    if (!dragRef.current.active) return
+    dragRef.current.active = false
+    const time = dragTime ?? seekTimeFromEvent(event)
+    setDragTime(null)
+    setSeekHoverTime(null)
+    playerRef.current?.currentTime(time)
+    try {
+      seekBarRef.current?.releasePointerCapture?.(event.pointerId)
+    } catch {
+      // 忽略释放失败
+    }
+    scheduleHideControls()
+  }
+
+  const handleSeekBarKeyDown = (event) => {
+    let next = null
+    if (event.key === 'ArrowLeft') {
+      next = (dragTime ?? currentTime) - 5
+    } else if (event.key === 'ArrowRight') {
+      next = (dragTime ?? currentTime) + 5
+    } else if (event.key === 'Home') {
+      next = 0
+    } else if (event.key === 'End') {
+      next = duration
+    }
+    if (next == null) return
+    event.preventDefault()
+    playerRef.current?.currentTime(Math.min(Math.max(0, next), duration))
+  }
 
   if (!video) return null
 
   const displayName = getVideoDisplayName(video)
   const aspectRatio =
     videoSize && videoSize.height > 0 ? videoSize.width / videoSize.height : 16 / 9
+  const displayTime = dragTime ?? currentTime
+  const playedPercent = duration > 0 ? clampPercent((displayTime / duration) * 100) : 0
+  const bufferedPercent = duration > 0 ? clampPercent((bufferedEnd / duration) * 100) : 0
+  const tooltipTime = dragTime ?? seekHoverTime
+  const tooltipPercent =
+    duration > 0 && tooltipTime != null ? clampPercent((tooltipTime / duration) * 100) : 0
 
   return (
     <div className="fixed inset-0 z-[1700] flex items-center justify-center bg-black/70 pointer-coarse:bg-black">
@@ -294,19 +734,24 @@ export default function PlayerModal({
         <button
           aria-label={zh('关闭', 'Close')}
           onClick={onClose}
-          className="absolute right-3 top-3 z-20 rounded-full bg-black/60 px-2 py-1 text-sm text-white hover:bg-black/80"
+          className={`absolute right-3 top-4 z-20 rounded-full bg-black/60 px-2 py-1 text-sm text-white hover:bg-black/80 pointer-coarse:top-3 pointer-coarse:transition-opacity pointer-coarse:duration-200 ${
+            controlsVisible ? '' : 'pointer-coarse:pointer-events-none pointer-coarse:opacity-0'
+          }`}
         >
           ×
         </button>
         <div className="flex flex-col gap-4 p-4 pointer-coarse:gap-0 pointer-coarse:p-0">
           <h2
-            className="truncate pr-10 text-lg font-semibold pointer-coarse:absolute pointer-coarse:inset-x-0 pointer-coarse:top-0 pointer-coarse:z-10 pointer-coarse:bg-gradient-to-b pointer-coarse:from-black/60 pointer-coarse:to-transparent pointer-coarse:px-12 pointer-coarse:pb-5 pointer-coarse:pt-2 pointer-coarse:text-sm pointer-coarse:font-medium pointer-coarse:text-white"
+            className={`truncate pr-10 text-lg font-semibold pointer-coarse:absolute pointer-coarse:inset-x-0 pointer-coarse:top-0 pointer-coarse:z-10 pointer-coarse:bg-gradient-to-b pointer-coarse:from-black/60 pointer-coarse:to-transparent pointer-coarse:pb-5 pointer-coarse:pl-3 pointer-coarse:pr-14 pointer-coarse:pt-4 pointer-coarse:text-sm pointer-coarse:font-medium pointer-coarse:text-white pointer-coarse:transition-opacity pointer-coarse:duration-200 ${
+              controlsVisible ? '' : 'pointer-coarse:pointer-events-none pointer-coarse:opacity-0'
+            }`}
             title={displayName}
           >
             {displayName}
           </h2>
           <div
-            className="player-shell relative w-full bg-black"
+            ref={shellRef}
+            className={`player-shell relative w-full bg-black ${controlsVisible ? '' : 'cursor-none'}`}
             style={{
               aspectRatio: videoSize ? `${videoSize.width} / ${videoSize.height}` : '16 / 9',
             }}
@@ -326,15 +771,229 @@ export default function PlayerModal({
               </div>
             ) : (
               <div data-vjs-player className="h-full w-full">
-                <video
-                  ref={videoRef}
-                  className="video-js vjs-big-play-centered h-full w-full"
-                  playsInline
-                >
+                <video ref={videoRef} className="video-js h-full w-full" playsInline>
                   <track kind="captions" />
                 </video>
               </div>
             )}
+
+            {/* 缓冲中加载动画 */}
+            {!loadingPlayback && !playbackError && waiting && playing ? (
+              <div className="pointer-events-none absolute left-1/2 top-1/2 z-10 -translate-x-1/2 -translate-y-1/2">
+                <div className="h-12 w-12 animate-spin rounded-full border-4 border-white/20 border-t-white" />
+              </div>
+            ) : null}
+
+            {/* 暂停/结束时的中央大按钮 */}
+            {!loadingPlayback && !playbackError && !playing ? (
+              <button
+                type="button"
+                aria-label={ended ? zh('重新播放', 'Replay') : zh('播放', 'Play')}
+                onClick={(event) => {
+                  event.stopPropagation()
+                  pokeControls()
+                  actionsRef.current?.togglePlay()
+                }}
+                className="absolute left-1/2 top-1/2 z-10 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white/10 p-4 text-white backdrop-blur-sm transition-colors hover:bg-white/25"
+              >
+                {ended ? (
+                  <ReplayIcon style={{ fontSize: 44 }} />
+                ) : (
+                  <PlayArrowIcon style={{ fontSize: 44 }} />
+                )}
+              </button>
+            ) : null}
+
+            {/* YouTube 风格控制条 */}
+            <div
+              className={`player-controls absolute inset-x-0 bottom-0 z-20 select-none bg-gradient-to-t from-black/80 via-black/40 to-transparent pb-1 transition-opacity duration-200 ${
+                controlsVisible ? 'opacity-100' : 'pointer-events-none opacity-0'
+              }`}
+            >
+              {/* 进度条 */}
+              <div
+                ref={seekBarRef}
+                role="slider"
+                tabIndex={0}
+                aria-label={zh('播放进度', 'Seek')}
+                aria-valuemin={0}
+                aria-valuemax={Math.round(duration)}
+                aria-valuenow={Math.round(displayTime)}
+                className="group/seek relative h-5 w-full cursor-pointer touch-none"
+                onPointerDown={handleSeekPointerDown}
+                onPointerMove={handleSeekPointerMove}
+                onPointerUp={handleSeekPointerUp}
+                onPointerCancel={handleSeekPointerUp}
+                onPointerLeave={() => setSeekHoverTime(null)}
+                onKeyDown={handleSeekBarKeyDown}
+              >
+                {tooltipTime != null && duration > 0 ? (
+                  <div
+                    className="pointer-events-none absolute -top-8 z-10 -translate-x-1/2 rounded-md bg-black/90 px-2 py-0.5 text-xs font-medium tabular-nums text-white shadow"
+                    style={{ left: `${tooltipPercent}%` }}
+                  >
+                    {formatTime(tooltipTime)}
+                  </div>
+                ) : null}
+                <div className="absolute inset-x-0 top-1/2 h-1 -translate-y-1/2 rounded-full bg-white/25 transition-all duration-100 group-hover/seek:h-1.5">
+                  <div
+                    className="absolute inset-y-0 left-0 rounded-full bg-white/50"
+                    style={{ width: `${bufferedPercent}%` }}
+                  />
+                  <div
+                    className="absolute inset-y-0 left-0 rounded-full bg-[#f00]"
+                    style={{ width: `${playedPercent}%` }}
+                  />
+                </div>
+                <div
+                  className={`pointer-events-none absolute top-1/2 h-3.5 w-3.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white shadow-md transition-opacity ${
+                    dragTime != null ? 'opacity-100' : 'opacity-0 group-hover/seek:opacity-100'
+                  }`}
+                  style={{ left: `${playedPercent}%` }}
+                />
+              </div>
+
+              {/* 按钮行 */}
+              <div className="flex items-center justify-between gap-2 px-3 pb-0.5">
+                <div className="flex min-w-0 items-center">
+                  <button
+                    type="button"
+                    aria-label={playing ? zh('暂停', 'Pause') : zh('播放', 'Play')}
+                    onClick={() => actionsRef.current?.togglePlay()}
+                    className={iconButtonClass}
+                  >
+                    {playing ? (
+                      <PauseIcon style={{ fontSize: 30 }} />
+                    ) : (
+                      <PlayArrowIcon style={{ fontSize: 30 }} />
+                    )}
+                  </button>
+                  <button
+                    type="button"
+                    aria-label={zh('后退 10 秒', 'Back 10 seconds')}
+                    onClick={() => actionsRef.current?.seekBy(-SEEK_STEP_SECONDS)}
+                    className={`${iconButtonClass} pointer-coarse:hidden`}
+                  >
+                    <Replay10Icon />
+                  </button>
+                  <button
+                    type="button"
+                    aria-label={zh('前进 10 秒', 'Forward 10 seconds')}
+                    onClick={() => actionsRef.current?.seekBy(SEEK_STEP_SECONDS)}
+                    className={`${iconButtonClass} pointer-coarse:hidden`}
+                  >
+                    <Forward10Icon />
+                  </button>
+
+                  {/* 音量 */}
+                  <div className="group/vol relative flex items-center">
+                    <button
+                      type="button"
+                      aria-label={
+                        muted || volume === 0 ? zh('取消静音', 'Unmute') : zh('静音', 'Mute')
+                      }
+                      onClick={() => actionsRef.current?.toggleMute()}
+                      className={iconButtonClass}
+                    >
+                      {muted || volume === 0 ? (
+                        <VolumeOffIcon />
+                      ) : volume < 0.5 ? (
+                        <VolumeDownIcon />
+                      ) : (
+                        <VolumeUpIcon />
+                      )}
+                    </button>
+                    <div className="flex w-0 items-center overflow-hidden opacity-0 transition-all duration-200 group-hover/vol:w-24 group-hover/vol:opacity-100 pointer-coarse:w-16 pointer-coarse:opacity-100">
+                      <input
+                        type="range"
+                        min={0}
+                        max={1}
+                        step={0.05}
+                        value={muted ? 0 : volume}
+                        onChange={(event) => actionsRef.current?.setVolumeLevel(event.target.value)}
+                        aria-label={zh('音量', 'Volume')}
+                        className="h-1 w-16 cursor-pointer accent-white pointer-coarse:w-12"
+                      />
+                    </div>
+                  </div>
+
+                  <div className="ml-1 whitespace-nowrap text-xs font-medium tabular-nums text-white/90">
+                    <span>{formatTime(displayTime)}</span>
+                    <span className="mx-0.5 text-white/60">/</span>
+                    <span className="text-white/60">{formatTime(duration)}</span>
+                  </div>
+                </div>
+
+                <div className="flex shrink-0 items-center">
+                  <button
+                    type="button"
+                    aria-label={zh('截图', 'Screenshot')}
+                    title={
+                      screenshotHotkeyLabel
+                        ? `${zh('截图', 'Screenshot')} (${screenshotHotkeyLabel})`
+                        : zh('截图', 'Screenshot')
+                    }
+                    onClick={() => actionsRef.current?.captureScreenshot()}
+                    className={iconButtonClass}
+                  >
+                    <PhotoCameraIcon />
+                  </button>
+
+                  {/* 播放速度菜单 */}
+                  <div className="relative">
+                    <button
+                      type="button"
+                      aria-label={zh('播放速度', 'Playback speed')}
+                      onClick={() => {
+                        setMenuOpen(menuOpen === 'speed' ? null : 'speed')
+                        showControls()
+                      }}
+                      className={iconButtonClass}
+                    >
+                      <SettingsIcon />
+                    </button>
+                    {menuOpen === 'speed' ? (
+                      <div className="absolute bottom-12 right-0 z-30 w-40 overflow-hidden rounded-xl border border-white/10 bg-black/90 py-1.5 shadow-2xl backdrop-blur-sm">
+                        <div className="px-3.5 pb-1 pt-1 text-xs font-semibold uppercase tracking-wider text-white/60">
+                          {zh('播放速度', 'Playback speed')}
+                        </div>
+                        {PLAYBACK_RATES.map((rate) => {
+                          const active = rate === playbackRate
+                          return (
+                            <button
+                              key={rate}
+                              type="button"
+                              onClick={() => {
+                                actionsRef.current?.setRate(rate)
+                                setMenuOpen(null)
+                                scheduleHideControls()
+                              }}
+                              className={`flex w-full items-center justify-between px-3.5 py-1.5 text-sm transition-colors hover:bg-white/10 ${
+                                active ? 'font-semibold text-white' : 'text-white/80'
+                              }`}
+                            >
+                              <span>{rate}x</span>
+                              {active ? <CheckIcon fontSize="small" /> : null}
+                            </button>
+                          )
+                        })}
+                      </div>
+                    ) : null}
+                  </div>
+
+                  <button
+                    type="button"
+                    aria-label={
+                      isFullscreen ? zh('退出全屏', 'Exit fullscreen') : zh('全屏', 'Fullscreen')
+                    }
+                    onClick={() => actionsRef.current?.toggleFullscreen()}
+                    className={iconButtonClass}
+                  >
+                    {isFullscreen ? <FullscreenExitIcon /> : <FullscreenIcon />}
+                  </button>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/web/src/components/TopBar.jsx
+++ b/web/src/components/TopBar.jsx
@@ -325,6 +325,15 @@ export default function TopBar({
     onEnabledDirectoryIdsChange?.(Array.from(next))
   }
 
+  // Directory checkbox is a three-state cycle: unchecked (empty) or partially
+  // enabled (special mark, some subdirectories hidden) toggles to fully
+  // enabled; fully enabled toggles the directory off.
+  const toggleDirectoryEnabled = (id) => {
+    const fullyEnabled =
+      enabledDirectorySet.has(id) && (closedSubdirectories?.[id] || []).length === 0
+    setDirectoryEnabled(id, !fullyEnabled)
+  }
+
   const toggleDirectoryExpanded = (id, nodePath = '') => {
     const key = `${id}:${nodePath}`
     setExpandedDirectoryIds((prev) => {
@@ -425,6 +434,56 @@ export default function TopBar({
   const setSubdirectoryEnabled = (directoryId, nodePath, checked) => {
     const closed = new Set(closedSubdirectories?.[directoryId] || [])
     if (checked) {
+      if (!enabledDirectorySet.has(directoryId)) {
+        // The parent directory is disabled: checking any subdirectory enables
+        // the directory and shows only that subdirectory's contents (every
+        // other top-level subdirectory and any sibling under the checked
+        // node's top-level ancestor is closed). Direct files of the ancestor
+        // cannot be hidden by a path prefix, so they remain visible.
+        const enabled = new Set(enabledDirectorySet)
+        enabled.add(directoryId)
+        const layout = subdirsByDirectory[directoryId]
+        const topNodes = layout?.subdirectories || []
+        if (topNodes.length > 0) {
+          let topAncestor = nodePath
+          while (topAncestor.includes('/')) {
+            topAncestor = topAncestor.slice(0, topAncestor.lastIndexOf('/'))
+          }
+          const nextClosed = new Set()
+          for (const top of topNodes) {
+            if (top.path !== topAncestor) {
+              nextClosed.add(top.path)
+            }
+          }
+          const collectNodePaths = (node, out) => {
+            out.push(node.path)
+            for (const child of node.subdirectories || []) {
+              collectNodePaths(child, out)
+            }
+            return out
+          }
+          const topNode = topNodes.find((top) => top.path === topAncestor)
+          for (const path of collectNodePaths(topNode, [])) {
+            if (
+              path !== nodePath &&
+              path !== topAncestor &&
+              !path.startsWith(nodePath + '/') &&
+              !nodePath.startsWith(path + '/')
+            ) {
+              nextClosed.add(path)
+            }
+          }
+          closed.clear()
+          for (const path of nextClosed) {
+            closed.add(path)
+          }
+        } else {
+          closed.clear()
+        }
+        onEnabledDirectoryIdsChange?.(Array.from(enabled))
+        onClosedSubdirectoriesChange?.(directoryId, Array.from(closed))
+        return
+      }
       // Opening a node reveals its whole subtree: remove the node and all
       // descendant entries from the closed list.
       closed.delete(nodePath)
@@ -460,15 +519,19 @@ export default function TopBar({
 
   // Recursively renders one subdirectory row: checkbox, name, file count and an
   // expand/collapse arrow when the node has children of its own.
-  const renderDirectoryBranch = (directoryId, node, ancestorsClosed, closedList) => {
+  const renderDirectoryBranch = (directoryId, node, parentEnabled, ancestorsClosed, closedList) => {
     const nodePath = node.path
     const nodeClosed = nodeIsClosed(closedList, nodePath)
     const children = node.subdirectories || []
     const expanded = expandedDirectoryIds.has(`${directoryId}:${nodePath}`)
-    // A node hidden by an ancestor cannot be re-enabled on its own, but a node
-    // that is itself closed stays clickable so checking it restores its subtree.
+    // A node hidden by a closed ancestor cannot be re-enabled on its own, but a
+    // node that is itself closed stays clickable so checking it restores its
+    // subtree. When the parent directory is disabled, subdirectories render as
+    // unchecked but stay clickable so checking one enables only its contents.
     const disabled = ancestorsClosed
-    const { checked, indeterminate } = nodeDisplayState(node, closedList)
+    const { checked, indeterminate } = parentEnabled
+      ? nodeDisplayState(node, closedList)
+      : { checked: false, indeterminate: false }
 
     return (
       <div key={nodePath}>
@@ -524,7 +587,13 @@ export default function TopBar({
         {expanded && children.length > 0 ? (
           <div className="border-l border-gray-100 pb-1 pl-4">
             {children.map((child) =>
-              renderDirectoryBranch(directoryId, child, ancestorsClosed || nodeClosed, closedList)
+              renderDirectoryBranch(
+                directoryId,
+                child,
+                parentEnabled,
+                ancestorsClosed || nodeClosed,
+                closedList
+              )
             )}
           </div>
         ) : null}
@@ -1093,19 +1162,9 @@ export default function TopBar({
                       const closedArray = Array.from(closedNames)
                       const expanded = expandedDirectoryIds.has(`${id}:`)
                       const hasSubdirectories = subdirectories.length > 0
-                      const topStates = subdirectories.map((subdir) =>
-                        nodeDisplayState(subdir, closedArray)
-                      )
-                      const topHiddenCount = topStates.filter((state) => !state.checked).length
-                      // A directory is partially enabled when some of its
-                      // subdirectories are hidden, or when every subdirectory is
-                      // hidden but files directly at the root remain visible.
-                      const partiallyEnabled =
-                        checked &&
-                        ((topHiddenCount > 0 && topHiddenCount < subdirectories.length) ||
-                          (hasSubdirectories &&
-                            topHiddenCount === subdirectories.length &&
-                            hasRootFiles))
+                      // A directory is partially enabled (special mark) when it
+                      // is enabled but any subdirectory at any level is hidden.
+                      const partiallyEnabled = checked && closedArray.length > 0
                       return (
                         <div key={directory.id}>
                           <div className="flex items-start gap-2 px-3 py-2 text-sm hover:bg-gray-50">
@@ -1113,7 +1172,7 @@ export default function TopBar({
                               <TriStateCheckbox
                                 checked={checked}
                                 indeterminate={partiallyEnabled}
-                                onChange={(event) => setDirectoryEnabled(id, event.target.checked)}
+                                onChange={() => toggleDirectoryEnabled(id)}
                                 className="mt-0.5 h-4 w-4 shrink-0 rounded border-gray-300 text-blue-600"
                                 aria-label={zh(
                                   `启用目录 ${directoryPath}`,
@@ -1190,7 +1249,7 @@ export default function TopBar({
                               ) : (
                                 <>
                                   {subdirectories.map((subdir) =>
-                                    renderDirectoryBranch(id, subdir, !checked, closedArray)
+                                    renderDirectoryBranch(id, subdir, checked, false, closedArray)
                                   )}
                                   {hasRootFiles ? (
                                     <div className="flex items-center gap-2 px-3 py-1.5 text-sm text-gray-500">

--- a/web/src/components/TopBar.jsx
+++ b/web/src/components/TopBar.jsx
@@ -14,9 +14,10 @@ import FolderOpenOutlinedIcon from '@mui/icons-material/FolderOpenOutlined'
 import ArrowBackRoundedIcon from '@mui/icons-material/ArrowBackRounded'
 import ArrowForwardRoundedIcon from '@mui/icons-material/ArrowForwardRounded'
 import KeyboardArrowDownRoundedIcon from '@mui/icons-material/KeyboardArrowDownRounded'
+import KeyboardArrowRightRoundedIcon from '@mui/icons-material/KeyboardArrowRightRounded'
 import CloseRoundedIcon from '@mui/icons-material/CloseRounded'
 import TuneOutlinedIcon from '@mui/icons-material/TuneOutlined'
-import { fetchJavPrefixes } from '@/api'
+import { fetchDirectorySubdirectories, fetchJavPrefixes } from '@/api'
 import JavPrefixModal from '@/components/JavPrefixModal'
 import { displayHostPath } from '@/utils/hostPath'
 import { zh } from '@/utils/i18n'
@@ -24,6 +25,17 @@ import { getErrorMessage } from '@/utils/errors'
 
 function ButtonTooltip({ enabled = true, title, ...props }) {
   return <Tooltip {...props} title={enabled ? title : ''} />
+}
+
+// Checkbox that also renders the indeterminate (partial) state.
+function TriStateCheckbox({ indeterminate = false, ...props }) {
+  const inputRef = useRef(null)
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.indeterminate = Boolean(indeterminate)
+    }
+  }, [indeterminate])
+  return <input ref={inputRef} type="checkbox" {...props} />
 }
 
 export default function TopBar({
@@ -78,6 +90,8 @@ export default function TopBar({
   directories = [],
   enabledDirectoryIds = [],
   onEnabledDirectoryIdsChange,
+  closedSubdirectories = {},
+  onClosedSubdirectoriesChange,
   hostPathPrefixEnabled = false,
   selectedCount = 0,
   onOpenSelectionOps,
@@ -88,6 +102,9 @@ export default function TopBar({
   const directoryMenuRef = useRef(null)
   const idolFavoriteMenuRef = useRef(null)
   const [directoryMenuOpen, setDirectoryMenuOpen] = useState(false)
+  const [expandedDirectoryIds, setExpandedDirectoryIds] = useState(() => new Set())
+  const [subdirsByDirectory, setSubdirsByDirectory] = useState({})
+  const [subdirsLoading, setSubdirsLoading] = useState(false)
   const [idolFavoriteMenuOpen, setIdolFavoriteMenuOpen] = useState(false)
   const [prefixModalOpen, setPrefixModalOpen] = useState(false)
   const [prefixItems, setPrefixItems] = useState([])
@@ -204,6 +221,44 @@ export default function TopBar({
   }, [javPrefixDirectoryIds, prefixModalOpen])
 
   useEffect(() => {
+    if (!directoryMenuOpen) return undefined
+    let cancelled = false
+    const ids = activeDirectories
+      .map((directory) => Number(directory.id))
+      .filter((id) => Number.isFinite(id) && id > 0)
+    if (ids.length === 0) return undefined
+    setSubdirsLoading(true)
+    Promise.all(
+      ids.map(async (id) => {
+        try {
+          const payload = await fetchDirectorySubdirectories(id)
+          return [
+            id,
+            {
+              rootVideoCount: Number(payload?.root_video_count) || 0,
+              subdirectories: Array.isArray(payload?.subdirectories) ? payload.subdirectories : [],
+            },
+          ]
+        } catch {
+          return [id, null]
+        }
+      })
+    ).then((results) => {
+      if (cancelled) return
+      const next = {}
+      for (const [id, payload] of results) {
+        if (payload) next[id] = payload
+      }
+      setSubdirsByDirectory(next)
+    }).finally(() => {
+      if (!cancelled) setSubdirsLoading(false)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [activeDirectories, directoryMenuOpen])
+
+  useEffect(() => {
     if (!directoryMenuOpen) return
 
     const handlePointerDown = (event) => {
@@ -263,7 +318,214 @@ export default function TopBar({
     } else {
       next.delete(id)
     }
+    // Toggling the master switch resets any per-subdirectory settings.
+    if (closedSubdirectories?.[id]?.length) {
+      onClosedSubdirectoriesChange?.(id, [])
+    }
     onEnabledDirectoryIdsChange?.(Array.from(next))
+  }
+
+  const toggleDirectoryExpanded = (id, nodePath = '') => {
+    const key = `${id}:${nodePath}`
+    setExpandedDirectoryIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(key)) {
+        next.delete(key)
+      } else {
+        next.add(key)
+      }
+      return next
+    })
+  }
+
+  // Returns true when the node itself or any of its ancestors is in the closed list.
+  const nodeIsClosed = (closedList, nodePath) => {
+    if (!nodePath) return false
+    if (closedList.includes(nodePath)) return true
+    return closedList.some((entry) => nodePath.startsWith(entry + '/'))
+  }
+
+  // Computes the checkbox display state of a tree node. A node whose every child
+  // is hidden counts as hidden too (unless it has direct files of its own), so
+  // parents can rely on these states instead of the raw closed list.
+  const nodeDisplayState = (node, closedList) => {
+    const selfClosed = nodeIsClosed(closedList, node.path)
+    const children = node.subdirectories || []
+    let checked
+    let indeterminate
+    if (selfClosed) {
+      checked = false
+      indeterminate = false
+    } else if (children.length === 0) {
+      checked = true
+      indeterminate = false
+    } else {
+      const childStates = children.map((child) => nodeDisplayState(child, closedList))
+      const hiddenCount = childStates.filter((state) => !state.checked).length
+      if (hiddenCount === 0) {
+        checked = true
+        indeterminate = false
+      } else if (hiddenCount === children.length) {
+        const hasDirect = Number(node.direct_video_count) > 0
+        checked = hasDirect
+        indeterminate = hasDirect
+      } else {
+        checked = true
+        indeterminate = true
+      }
+    }
+    return { checked, indeterminate }
+  }
+
+  const findTreeNode = (nodes, targetPath) => {
+    for (const node of nodes || []) {
+      if (node.path === targetPath) return node
+      const found = findTreeNode(node.subdirectories, targetPath)
+      if (found) return found
+    }
+    return null
+  }
+
+  // Closes nodePath (already added to closed) and propagates upward: when every
+  // direct child of the parent is closed and the parent has no direct files, the
+  // parent closes too. Returns true when the whole directory was turned off.
+  const propagateClose = (directoryId, nodePath, closed, enabled) => {
+    const idx = nodePath.lastIndexOf('/')
+    const parentPath = idx === -1 ? '' : nodePath.slice(0, idx)
+    const layout = subdirsByDirectory[directoryId] || { rootVideoCount: 0, subdirectories: [] }
+    if (parentPath === '') {
+      const topChildren = layout.subdirectories || []
+      if (
+        topChildren.length > 0 &&
+        topChildren.every((child) => !nodeDisplayState(child, closed).checked) &&
+        Number(layout.rootVideoCount) === 0
+      ) {
+        enabled.delete(directoryId)
+        closed.clear()
+        return true
+      }
+      return false
+    }
+    const parent = findTreeNode(layout.subdirectories, parentPath)
+    if (!parent) return false
+    const children = parent.subdirectories || []
+    if (
+      children.length > 0 &&
+      children.every((child) => !nodeDisplayState(child, closed).checked) &&
+      Number(parent.direct_video_count) === 0
+    ) {
+      closed.add(parentPath)
+      return propagateClose(directoryId, parentPath, closed, enabled)
+    }
+    return false
+  }
+
+  const setSubdirectoryEnabled = (directoryId, nodePath, checked) => {
+    const closed = new Set(closedSubdirectories?.[directoryId] || [])
+    if (checked) {
+      // Opening a node reveals its whole subtree: remove the node and all
+      // descendant entries from the closed list.
+      closed.delete(nodePath)
+      for (const entry of Array.from(closed)) {
+        if (entry.startsWith(nodePath + '/')) {
+          closed.delete(entry)
+        }
+      }
+    } else {
+      closed.add(nodePath)
+      for (const entry of Array.from(closed)) {
+        if (entry !== nodePath && entry.startsWith(nodePath + '/')) {
+          closed.delete(entry)
+        }
+      }
+      const enabled = new Set(enabledDirectorySet)
+      if (propagateClose(directoryId, nodePath, closed, enabled)) {
+        onClosedSubdirectoriesChange?.(directoryId, [])
+        onEnabledDirectoryIdsChange?.(Array.from(enabled))
+        return
+      }
+    }
+    onClosedSubdirectoriesChange?.(directoryId, Array.from(closed))
+  }
+
+  const clearAllClosedSubdirectories = () => {
+    for (const id of activeDirectoryIds) {
+      if (closedSubdirectories?.[id]?.length) {
+        onClosedSubdirectoriesChange?.(id, [])
+      }
+    }
+  }
+
+  // Recursively renders one subdirectory row: checkbox, name, file count and an
+  // expand/collapse arrow when the node has children of its own.
+  const renderDirectoryBranch = (directoryId, node, ancestorsClosed, closedList) => {
+    const nodePath = node.path
+    const nodeClosed = nodeIsClosed(closedList, nodePath)
+    const children = node.subdirectories || []
+    const expanded = expandedDirectoryIds.has(`${directoryId}:${nodePath}`)
+    const disabled = ancestorsClosed || nodeClosed
+    const { checked, indeterminate } = nodeDisplayState(node, closedList)
+
+    return (
+      <div key={nodePath}>
+        <div className="flex items-center gap-2 px-3 py-1.5 text-sm hover:bg-gray-50">
+          <TriStateCheckbox
+            checked={checked}
+            indeterminate={indeterminate}
+            disabled={disabled}
+            onChange={(event) =>
+              setSubdirectoryEnabled(directoryId, nodePath, event.target.checked)
+            }
+            className="h-4 w-4 shrink-0 rounded border-gray-300 text-blue-600 disabled:opacity-40"
+            aria-label={zh(
+              `显示子目录 ${node.name} 的内容`,
+              `Show contents of subdirectory ${node.name}`
+            )}
+          />
+          <span className="min-w-0 flex-1 truncate text-gray-700">{node.name}</span>
+          <span
+            className="shrink-0 text-xs tabular-nums text-gray-400"
+            title={zh(
+              `目录内文件数 ${node.video_count}`,
+              `Files in directory: ${node.video_count}`
+            )}
+          >
+            {Number(node.video_count) || 0}
+          </span>
+          {children.length > 0 ? (
+            <button
+              type="button"
+              onClick={(event) => {
+                event.preventDefault()
+                event.stopPropagation()
+                toggleDirectoryExpanded(directoryId, nodePath)
+              }}
+              aria-label={
+                expanded
+                  ? zh(`收起子目录 ${node.name}`, `Collapse subdirectories of ${node.name}`)
+                  : zh(`展开子目录 ${node.name}`, `Expand subdirectories of ${node.name}`)
+              }
+              aria-expanded={expanded}
+              className="flex h-6 w-6 shrink-0 items-center justify-center rounded text-gray-500 hover:bg-gray-100 hover:text-gray-700"
+            >
+              <KeyboardArrowRightRoundedIcon
+                fontSize="small"
+                className={
+                  expanded ? 'rotate-90 transition-transform' : 'transition-transform'
+                }
+              />
+            </button>
+          ) : null}
+        </div>
+        {expanded && children.length > 0 ? (
+          <div className="border-l border-gray-100 pb-1 pl-4">
+            {children.map((child) =>
+              renderDirectoryBranch(directoryId, child, ancestorsClosed || nodeClosed, closedList)
+            )}
+          </div>
+        ) : null}
+      </div>
+    )
   }
 
   const handleIdolFavoriteMenuToggle = () => {
@@ -786,14 +1048,20 @@ export default function TopBar({
                     <div className="flex shrink-0 items-center gap-1">
                       <button
                         type="button"
-                        onClick={() => onEnabledDirectoryIdsChange?.(activeDirectoryIds)}
+                        onClick={() => {
+                          onEnabledDirectoryIdsChange?.(activeDirectoryIds)
+                          clearAllClosedSubdirectories()
+                        }}
                         className="rounded border border-gray-200 bg-white px-2 py-1 text-xs text-gray-600 hover:bg-gray-100"
                       >
                         {zh('全选', 'All')}
                       </button>
                       <button
                         type="button"
-                        onClick={() => onEnabledDirectoryIdsChange?.([])}
+                        onClick={() => {
+                          onEnabledDirectoryIdsChange?.([])
+                          clearAllClosedSubdirectories()
+                        }}
                         className="rounded border border-gray-200 bg-white px-2 py-1 text-xs text-gray-600 hover:bg-gray-100"
                       >
                         {zh('清空', 'None')}
@@ -811,30 +1079,133 @@ export default function TopBar({
                       const id = Number(directory.id)
                       const checked = enabledDirectorySet.has(id)
                       const directoryPath = displayHostPath(directory.path, hostPathPrefixEnabled)
+                      const closedNames = new Set(closedSubdirectories?.[id] || [])
+                      const directoryLayout = subdirsByDirectory[id] || {
+                        rootVideoCount: 0,
+                        subdirectories: [],
+                      }
+                      const subdirectories = directoryLayout.subdirectories || []
+                      const hasRootFiles = Number(directoryLayout.rootVideoCount) > 0
+                      const closedArray = Array.from(closedNames)
+                      const expanded = expandedDirectoryIds.has(`${id}:`)
+                      const hasSubdirectories = subdirectories.length > 0
+                      const topStates = subdirectories.map((subdir) =>
+                        nodeDisplayState(subdir, closedArray)
+                      )
+                      const topHiddenCount = topStates.filter((state) => !state.checked).length
+                      // A directory is partially enabled when some of its
+                      // subdirectories are hidden, or when every subdirectory is
+                      // hidden but files directly at the root remain visible.
+                      const partiallyEnabled =
+                        checked &&
+                        ((topHiddenCount > 0 && topHiddenCount < subdirectories.length) ||
+                          (hasSubdirectories &&
+                            topHiddenCount === subdirectories.length &&
+                            hasRootFiles))
                       return (
-                        <label
-                          key={directory.id}
-                          className="flex cursor-pointer items-start gap-2 px-3 py-2 text-sm hover:bg-gray-50"
-                        >
-                          <input
-                            type="checkbox"
-                            checked={checked}
-                            onChange={(event) => setDirectoryEnabled(id, event.target.checked)}
-                            className="mt-0.5 h-4 w-4 shrink-0 rounded border-gray-300 text-blue-600"
-                            aria-label={zh(
-                              `启用目录 ${directoryPath}`,
-                              `Enable directory ${directoryPath}`
-                            )}
-                          />
-                          <span className="min-w-0 flex-1 text-gray-700">
-                            <span className="break-all">{directoryPath}</span>
-                            {directory.missing ? (
-                              <span className="ml-2 inline-flex rounded-full bg-red-50 px-2 py-0.5 text-xs font-medium text-red-700">
-                                {zh('目录缺失', 'Missing')}
+                        <div key={directory.id}>
+                          <div className="flex items-start gap-2 px-3 py-2 text-sm hover:bg-gray-50">
+                            <label className="flex min-w-0 flex-1 cursor-pointer items-start gap-2">
+                              <TriStateCheckbox
+                                checked={checked}
+                                indeterminate={partiallyEnabled}
+                                onChange={(event) => setDirectoryEnabled(id, event.target.checked)}
+                                className="mt-0.5 h-4 w-4 shrink-0 rounded border-gray-300 text-blue-600"
+                                aria-label={zh(
+                                  `启用目录 ${directoryPath}`,
+                                  `Enable directory ${directoryPath}`
+                                )}
+                              />
+                              <span className="min-w-0 flex-1 text-gray-700">
+                                <span className="break-all">{directoryPath}</span>
+                                {closedArray.length > 0 ? (
+                                  <span className="ml-2 inline-flex rounded-full bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-700">
+                                    {zh(
+                                      `部分子目录已隐藏`,
+                                      'Some subdirectories hidden'
+                                    )}
+                                  </span>
+                                ) : null}
+                                {directory.missing ? (
+                                  <span className="ml-2 inline-flex rounded-full bg-red-50 px-2 py-0.5 text-xs font-medium text-red-700">
+                                    {zh('目录缺失', 'Missing')}
+                                  </span>
+                                ) : null}
                               </span>
+                            </label>
+                            {hasSubdirectories ? (
+                              <div className="flex shrink-0 items-center gap-0.5">
+                                <span
+                                  className="text-xs tabular-nums text-gray-400"
+                                  title={zh(
+                                    `目录内文件数 ${directory.scanned_video_count}`,
+                                    `Files in directory: ${directory.scanned_video_count}`
+                                  )}
+                                >
+                                  {Number(directory.scanned_video_count) || 0}
+                                </span>
+                                <button
+                                  type="button"
+                                  onClick={(event) => {
+                                    event.preventDefault()
+                                    event.stopPropagation()
+                                    toggleDirectoryExpanded(id, '')
+                                  }}
+                                  aria-label={
+                                    expanded
+                                      ? zh(
+                                          `收起子目录 ${directoryPath}`,
+                                          `Collapse subdirectories of ${directoryPath}`
+                                        )
+                                      : zh(
+                                          `展开子目录 ${directoryPath}`,
+                                          `Expand subdirectories of ${directoryPath}`
+                                        )
+                                  }
+                                  aria-expanded={expanded}
+                                  className="flex h-6 w-6 shrink-0 items-center justify-center rounded text-gray-500 hover:bg-gray-100 hover:text-gray-700"
+                                >
+                                  <KeyboardArrowRightRoundedIcon
+                                    fontSize="small"
+                                    className={
+                                      expanded
+                                        ? 'rotate-90 transition-transform'
+                                        : 'transition-transform'
+                                    }
+                                  />
+                                </button>
+                              </div>
                             ) : null}
-                          </span>
-                        </label>
+                          </div>
+                          {expanded ? (
+                            <div className="border-l border-gray-100 pb-1 pl-4">
+                              {subdirsLoading && subdirectories.length === 0 ? (
+                                <div className="px-3 py-1.5 text-xs text-gray-400">
+                                  {zh('加载子目录…', 'Loading subdirectories...')}
+                                </div>
+                              ) : (
+                                <>
+                                  {subdirectories.map((subdir) =>
+                                    renderDirectoryBranch(id, subdir, !checked, closedArray)
+                                  )}
+                                  {hasRootFiles ? (
+                                    <div className="flex items-center gap-2 px-3 py-1.5 text-sm text-gray-500">
+                                      <span className="flex h-4 w-4 shrink-0 items-center justify-center">
+                                        <FolderRoundedIcon fontSize="small" className="text-gray-400" />
+                                      </span>
+                                      <span className="min-w-0 flex-1 truncate">
+                                        {zh('(根目录)', '(Root)')}
+                                      </span>
+                                      <span className="shrink-0 text-xs tabular-nums text-gray-400">
+                                        {Number(directoryLayout.rootVideoCount) || 0}
+                                      </span>
+                                    </div>
+                                  ) : null}
+                                </>
+                              )}
+                            </div>
+                          ) : null}
+                        </div>
                       )
                     })
                   )}

--- a/web/src/components/TopBar.jsx
+++ b/web/src/components/TopBar.jsx
@@ -393,11 +393,13 @@ export default function TopBar({
     const idx = nodePath.lastIndexOf('/')
     const parentPath = idx === -1 ? '' : nodePath.slice(0, idx)
     const layout = subdirsByDirectory[directoryId] || { rootVideoCount: 0, subdirectories: [] }
+    // nodeDisplayState expects an array (uses .includes/.some), so convert the Set.
+    const closedList = Array.from(closed)
     if (parentPath === '') {
       const topChildren = layout.subdirectories || []
       if (
         topChildren.length > 0 &&
-        topChildren.every((child) => !nodeDisplayState(child, closed).checked) &&
+        topChildren.every((child) => !nodeDisplayState(child, closedList).checked) &&
         Number(layout.rootVideoCount) === 0
       ) {
         enabled.delete(directoryId)
@@ -411,7 +413,7 @@ export default function TopBar({
     const children = parent.subdirectories || []
     if (
       children.length > 0 &&
-      children.every((child) => !nodeDisplayState(child, closed).checked) &&
+      children.every((child) => !nodeDisplayState(child, closedList).checked) &&
       Number(parent.direct_video_count) === 0
     ) {
       closed.add(parentPath)
@@ -463,7 +465,9 @@ export default function TopBar({
     const nodeClosed = nodeIsClosed(closedList, nodePath)
     const children = node.subdirectories || []
     const expanded = expandedDirectoryIds.has(`${directoryId}:${nodePath}`)
-    const disabled = ancestorsClosed || nodeClosed
+    // A node hidden by an ancestor cannot be re-enabled on its own, but a node
+    // that is itself closed stays clickable so checking it restores its subtree.
+    const disabled = ancestorsClosed
     const { checked, indeterminate } = nodeDisplayState(node, closedList)
 
     return (

--- a/web/src/components/VideoCard.jsx
+++ b/web/src/components/VideoCard.jsx
@@ -42,6 +42,16 @@ export default function VideoCard({
       ? `${meta.width}x${meta.height}`
       : ''
   const sizeText = formatBytes(meta.size || video?.size)
+  // 实际容器格式（ffprobe 探测，可能与扩展名不一致，如 TS 流改名 .mp4）
+  const actualFormat = String(video?.format || '')
+    .trim()
+    .toLowerCase()
+  const fileExt =
+    String(video?.filename || video?.path || '')
+      .split('.')
+      .pop()
+      ?.toLowerCase() || ''
+  const formatMismatch = Boolean(actualFormat && fileExt && fileExt !== actualFormat)
   const directoryPath = video?.directory?.path || video?.directory_path || ''
   const videoPath = video?.path || ''
   const canOpen = Boolean(directoryPath && videoPath)
@@ -189,6 +199,26 @@ export default function VideoCard({
           {sizeText ? (
             <span className="inline-flex h-4 items-center rounded bg-gray-100 px-1 text-[10px] font-medium text-gray-700">
               {sizeText}
+            </span>
+          ) : null}
+          {actualFormat ? (
+            <span
+              className={`inline-flex h-4 items-center rounded px-1 text-[10px] font-medium ${
+                formatMismatch ? 'bg-amber-200 text-amber-900' : 'bg-gray-100 text-gray-700'
+              }`}
+              title={
+                formatMismatch
+                  ? zh(
+                      `扩展名为 .${fileExt}，实际格式为 ${actualFormat.toUpperCase()}`,
+                      `Extension .${fileExt}, actual format ${actualFormat.toUpperCase()}`
+                    )
+                  : zh(
+                      `实际格式 ${actualFormat.toUpperCase()}`,
+                      `Actual format ${actualFormat.toUpperCase()}`
+                    )
+              }
+            >
+              {actualFormat.toUpperCase()}
             </span>
           ) : null}
         </div>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -318,6 +318,7 @@ body.has-page-scroll .sticky-pagination {
 
 .player-shell {
   position: relative;
+  overflow: hidden;
   background: #000;
 }
 
@@ -326,22 +327,24 @@ body.has-page-scroll .sticky-pagination {
   height: 100%;
 }
 
-.player-shell .vjs-volume-panel,
-.player-shell .vjs-volume-panel.vjs-volume-panel-horizontal,
-.player-shell .vjs-volume-panel.vjs-volume-panel-horizontal.vjs-mute-toggle-only {
-  width: 10em;
-  transition: none;
+/* 全屏（或比例不匹配）时视频等比缩放居中，避免拉伸 */
+.player-shell .video-js .vjs-tech {
+  object-fit: contain;
 }
 
-.player-shell .vjs-volume-panel .vjs-volume-control,
-.player-shell .vjs-volume-panel .vjs-volume-control.vjs-volume-horizontal {
-  visibility: visible;
-  opacity: 1;
-  position: relative;
-  width: 5em;
-  height: 3em;
-  margin: 0;
-  transition: none;
+/* 自定义控制条随 .player-shell 进入浏览器全屏 */
+.player-shell:fullscreen,
+.player-shell:-webkit-full-screen {
+  width: 100vw;
+  height: 100vh;
+  aspect-ratio: auto;
+  background: #000;
+}
+
+.player-shell:fullscreen .video-js,
+.player-shell:-webkit-full-screen .video-js {
+  width: 100%;
+  height: 100%;
 }
 
 .skeuo-tag {

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -297,25 +297,33 @@ body.has-page-scroll .sticky-pagination {
     0 1px 2px rgba(15, 23, 42, 0.16);
 }
 
+.player-card {
+  /* 视频比例由 React 通过 --player-ar 传入；宽度公式驱动等比例缩放 */
+  --player-ar: 16 / 9;
+  width: min(80vw, calc((80vh - 5rem) * var(--player-ar) + 2rem));
+}
+
+/* 移动端（触摸设备）：贴边全屏，隐藏白卡片边框；标题悬浮不占布局，因此无需预留标题高度。
+   用 pointer: coarse 而非宽度断点，覆盖横屏手机（宽度可能超过 640px） */
+@media (pointer: coarse) {
+  .player-card {
+    width: min(100vw, calc(100vh * var(--player-ar)));
+  }
+  @supports (height: 100dvh) {
+    .player-card {
+      width: min(100vw, calc(100dvh * var(--player-ar)));
+    }
+  }
+}
+
 .player-shell {
-  --player-controls-height: 30px;
-  height: 75vh;
-  padding-bottom: var(--player-controls-height);
-  box-sizing: border-box;
-  overflow: visible;
+  position: relative;
+  background: #000;
 }
 
 .player-shell .video-js {
   width: 100%;
   height: 100%;
-}
-
-.player-shell .vjs-control-bar {
-  transform: translateY(100%);
-  opacity: 1 !important;
-  visibility: visible !important;
-  pointer-events: auto !important;
-  display: flex !important;
 }
 
 .player-shell .vjs-volume-panel,
@@ -334,10 +342,6 @@ body.has-page-scroll .sticky-pagination {
   height: 3em;
   margin: 0;
   transition: none;
-}
-
-.player-shell .video-js.vjs-fullscreen .vjs-control-bar {
-  transform: none;
 }
 
 .skeuo-tag {

--- a/web/src/store.js
+++ b/web/src/store.js
@@ -88,6 +88,48 @@ const cleanDirectoryIds = (ids) =>
     new Set((ids || []).map((id) => Number(id)).filter((id) => Number.isFinite(id) && id > 0))
   ).sort((a, b) => a - b)
 
+// closedSubdirectories state shape: { [directoryId]: [subdirName, ...] }
+// It records first-level subdirectories hidden inside an otherwise enabled directory.
+const closedSubdirectoryPairs = (state) => {
+  const map = state?.closedSubdirectories || {}
+  const active = new Set(cleanDirectoryIds((state?.directories || []).map((d) => d?.id)))
+  const pairs = []
+  for (const [rawId, names] of Object.entries(map)) {
+    const id = Number(rawId)
+    if (!Number.isFinite(id) || id <= 0 || !active.has(id)) continue
+    if (!Array.isArray(names)) continue
+    for (const name of names) {
+      const clean = String(name || '').trim()
+      if (clean) pairs.push({ directoryId: id, name: clean })
+    }
+  }
+  return pairs.sort((a, b) =>
+    a.directoryId === b.directoryId
+      ? a.name.localeCompare(b.name)
+      : a.directoryId - b.directoryId
+  )
+}
+
+const closedSubdirsKey = (state) =>
+  closedSubdirectoryPairs(state)
+    .map((pair) => `${pair.directoryId}:${pair.name}`)
+    .join(',')
+
+// Keeps only closed-subdirectory entries whose directory is still active.
+const pruneClosedSubdirectories = (closed, directoryIds) => {
+  const keep = new Set(cleanDirectoryIds(directoryIds))
+  const next = {}
+  for (const [rawId, names] of Object.entries(closed || {})) {
+    const id = Number(rawId)
+    if (!Number.isFinite(id) || !keep.has(id)) continue
+    const cleanNames = Array.isArray(names)
+      ? Array.from(new Set(names.map((n) => String(n || '').trim()).filter(Boolean)))
+      : []
+    if (cleanNames.length > 0) next[id] = cleanNames
+  }
+  return next
+}
+
 const sameIds = (a, b) => {
   if (a === b) return true
   if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) return false
@@ -129,6 +171,7 @@ const videoListRequestKey = (state, directoryIds = directoryQueryIds(state)) => 
     state.randomMode ? state.randomSeed || '' : '',
     (state.selectedTags || []).join(','),
     directoryIds.join(','),
+    closedSubdirsKey(state),
     state.videoHideJav ? 'hide-jav' : 'show-jav',
   ].join('|')
 }
@@ -151,6 +194,7 @@ const javListRequestKey = (state, directoryIds = directoryQueryIds(state)) => {
     effectiveSort,
     state.javRandomMode ? state.javRandomSeed || '' : '',
     directoryIds.join(','),
+    closedSubdirsKey(state),
   ].join('|')
 }
 
@@ -164,6 +208,7 @@ const idolListRequestKey = (state, directoryIds = directoryQueryIds(state)) => {
     effectiveSort,
     state.idolFavoriteGroupId || '',
     directoryIds.join(','),
+    closedSubdirsKey(state),
   ].join('|')
 }
 
@@ -181,6 +226,7 @@ const studioListRequestKey = (state, directoryIds = directoryQueryIds(state)) =>
     state.javSearchTerm || '',
     state.studioFavoriteGroupId || '',
     directoryIds.join(','),
+    closedSubdirsKey(state),
   ].join('|')
 
 const seriesListRequestKey = (state, directoryIds = directoryQueryIds(state)) =>
@@ -191,6 +237,7 @@ const seriesListRequestKey = (state, directoryIds = directoryQueryIds(state)) =>
     state.javSearchTerm || '',
     state.seriesFavoriteGroupId || '',
     directoryIds.join(','),
+    closedSubdirsKey(state),
   ].join('|')
 
 export const useStore = create((set, get) => ({
@@ -334,6 +381,7 @@ export const useStore = create((set, get) => ({
   javTagOptions: [],
   directories: [],
   enabledDirectoryIds: [],
+  closedSubdirectories: {},
   directoryFilterMode: DIRECTORY_FILTER_ALL,
   loading: false,
   videoLoadingMore: false,
@@ -550,7 +598,8 @@ export const useStore = create((set, get) => ({
   loadTags: async (options = {}) => {
     const { videoHideJav } = get()
     const directoryIds = directoryQueryIds(get())
-    const key = `tags|${directoryIds.join(',')}|${videoHideJav ? 'hide-jav' : 'show-jav'}`
+    const closedSubdirs = closedSubdirectoryPairs(get())
+    const key = `tags|${directoryIds.join(',')}|${closedSubdirsKey(get())}|${videoHideJav ? 'hide-jav' : 'show-jav'}`
     if (tagFetchInFlight && tagFetchInFlightKey === key) {
       return tagFetchInFlight
     }
@@ -560,7 +609,7 @@ export const useStore = create((set, get) => ({
     tagFetchInFlightKey = key
     tagFetchInFlight = (async () => {
       try {
-        const tags = await fetchTags({ directoryIds, hideJav: videoHideJav })
+        const tags = await fetchTags({ directoryIds, closedSubdirs, hideJav: videoHideJav })
         set({ tags })
         lastTagFetchKey = key
         return tags
@@ -578,7 +627,8 @@ export const useStore = create((set, get) => ({
   },
   loadJavTags: async (options = {}) => {
     const directoryIds = directoryQueryIds(get())
-    const key = `jav-tags|${directoryIds.join(',')}`
+    const closedSubdirs = closedSubdirectoryPairs(get())
+    const key = `jav-tags|${directoryIds.join(',')}|${closedSubdirsKey(get())}`
     if (javTagFetchInFlight && javTagFetchInFlightKey === key) {
       return javTagFetchInFlight
     }
@@ -588,7 +638,7 @@ export const useStore = create((set, get) => ({
     javTagFetchInFlightKey = key
     javTagFetchInFlight = (async () => {
       try {
-        const tags = await fetchJavTags({ directoryIds })
+        const tags = await fetchJavTags({ directoryIds, closedSubdirs })
         set({ javTagOptions: tags })
         lastJavTagFetchKey = key
         return tags
@@ -708,6 +758,7 @@ export const useStore = create((set, get) => ({
         directories: active,
         enabledDirectoryIds: nextMode === DIRECTORY_FILTER_ALL ? activeIDs : enabled,
         directoryFilterMode: nextMode,
+        closedSubdirectories: pruneClosedSubdirectories(state.closedSubdirectories, activeIDs),
       })
     } catch (e) {
       console.error(zh('加载目录失败', 'Failed to load directories'), e)
@@ -726,6 +777,7 @@ export const useStore = create((set, get) => ({
       randomSeed,
     } = get()
     const directoryIds = directoryQueryIds(get())
+    const closedSubdirs = closedSubdirectoryPairs(get())
     const search = searchTerm ? searchTerm : ''
     const effectiveSort = videoTempSort || sortOrder
     const key = videoListRequestKey({ ...get(), page: p0 }, directoryIds)
@@ -744,6 +796,7 @@ export const useStore = create((set, get) => ({
         sort: randomMode ? 'random' : effectiveSort,
         seed: randomMode ? randomSeed : null,
         directoryIds,
+        closedSubdirs,
         hideJav: videoHideJav,
       })
       if (reqId !== videoLoadSeq || key !== videoListRequestKey(get())) return
@@ -770,6 +823,7 @@ export const useStore = create((set, get) => ({
     if (total > 0 && baseOffset + loaded >= total) return
 
     const directoryIds = directoryQueryIds(state)
+    const closedSubdirs = closedSubdirectoryPairs(state)
     const search = state.searchTerm ? state.searchTerm : ''
     const effectiveSort = state.videoTempSort || state.sortOrder
     const requestKey = videoListRequestKey(state, directoryIds)
@@ -784,6 +838,7 @@ export const useStore = create((set, get) => ({
         search,
         sort: effectiveSort,
         directoryIds,
+        closedSubdirs,
         hideJav: state.videoHideJav,
       })
       if (
@@ -835,6 +890,7 @@ export const useStore = create((set, get) => ({
       javRandomSeed,
     } = get()
     const directoryIds = directoryQueryIds(get())
+    const closedSubdirs = closedSubdirectoryPairs(get())
     const search = javSearchTerm || ''
     const effectiveSort = javTempSort || javSort
     const key = javListRequestKey(get(), directoryIds)
@@ -859,6 +915,7 @@ export const useStore = create((set, get) => ({
         sort: javRandomMode ? 'random' : effectiveSort,
         seed: javRandomMode ? javRandomSeed : null,
         directoryIds,
+        closedSubdirs,
       })
       if (reqId !== javLoadSeq || key !== javListRequestKey(get())) return
       const items = resp.items || []
@@ -884,6 +941,7 @@ export const useStore = create((set, get) => ({
     if (total > 0 && baseOffset + loaded >= total) return
 
     const directoryIds = directoryQueryIds(state)
+    const closedSubdirs = closedSubdirectoryPairs(state)
     const search = state.javSearchTerm || ''
     const effectiveSort = state.javTempSort || state.javSort
     const requestKey = javListRequestKey(state, directoryIds)
@@ -904,6 +962,7 @@ export const useStore = create((set, get) => ({
         favoriteGroupId: state.javFavoriteGroupId,
         sort: effectiveSort,
         directoryIds,
+        closedSubdirs,
       })
       if (
         loadReqId !== javLoadSeq ||
@@ -935,6 +994,7 @@ export const useStore = create((set, get) => ({
   loadJavIdols: async (options = {}) => {
     const { idolPage, idolPageSize, javSearchTerm, idolFavoriteGroupId } = get()
     const directoryIds = directoryQueryIds(get())
+    const closedSubdirs = closedSubdirectoryPairs(get())
     const search = javSearchTerm || ''
     const key = idolListRequestKey(get(), directoryIds)
     if (!options.force && key === lastIdolFetchKey) {
@@ -950,6 +1010,7 @@ export const useStore = create((set, get) => ({
         search,
         sort: effectiveIdolSort(get()),
         directoryIds,
+        closedSubdirs,
         favoriteGroupId: idolFavoriteGroupId,
       })
       if (reqId !== idolLoadSeq || key !== idolListRequestKey(get())) return
@@ -975,6 +1036,7 @@ export const useStore = create((set, get) => ({
     if (total > 0 && baseOffset + loaded >= total) return
 
     const directoryIds = directoryQueryIds(state)
+    const closedSubdirs = closedSubdirectoryPairs(state)
     const search = state.javSearchTerm || ''
     const requestKey = idolListRequestKey(state, directoryIds)
     const loadReqId = idolLoadSeq
@@ -987,6 +1049,7 @@ export const useStore = create((set, get) => ({
         search,
         sort: effectiveIdolSort(state),
         directoryIds,
+        closedSubdirs,
         favoriteGroupId: state.idolFavoriteGroupId,
       })
       if (
@@ -1055,6 +1118,7 @@ export const useStore = create((set, get) => ({
   loadJavStudios: async (options = {}) => {
     const { studioPage, studioPageSize, javSearchTerm, studioFavoriteGroupId } = get()
     const directoryIds = directoryQueryIds(get())
+    const closedSubdirs = closedSubdirectoryPairs(get())
     const search = javSearchTerm || ''
     const key = studioListRequestKey(get(), directoryIds)
     if (!options.force && key === lastStudioFetchKey) {
@@ -1069,6 +1133,7 @@ export const useStore = create((set, get) => ({
         offset: (studioPage - 1) * studioPageSize,
         search,
         directoryIds,
+        closedSubdirs,
         favoriteGroupId: studioFavoriteGroupId,
       })
       if (reqId !== studioLoadSeq || key !== studioListRequestKey(get())) return
@@ -1094,6 +1159,7 @@ export const useStore = create((set, get) => ({
     if (total > 0 && baseOffset + loaded >= total) return
 
     const directoryIds = directoryQueryIds(state)
+    const closedSubdirs = closedSubdirectoryPairs(state)
     const search = state.javSearchTerm || ''
     const requestKey = studioListRequestKey(state, directoryIds)
     const loadReqId = studioLoadSeq
@@ -1105,6 +1171,7 @@ export const useStore = create((set, get) => ({
         offset: baseOffset + loaded,
         search,
         directoryIds,
+        closedSubdirs,
         favoriteGroupId: state.studioFavoriteGroupId,
       })
       if (
@@ -1137,6 +1204,7 @@ export const useStore = create((set, get) => ({
   loadJavSeries: async (options = {}) => {
     const { seriesPage, seriesPageSize, javSearchTerm, seriesFavoriteGroupId } = get()
     const directoryIds = directoryQueryIds(get())
+    const closedSubdirs = closedSubdirectoryPairs(get())
     const search = javSearchTerm || ''
     const key = seriesListRequestKey(get(), directoryIds)
     if (!options.force && key === lastSeriesFetchKey) {
@@ -1151,6 +1219,7 @@ export const useStore = create((set, get) => ({
         offset: (seriesPage - 1) * seriesPageSize,
         search,
         directoryIds,
+        closedSubdirs,
         favoriteGroupId: seriesFavoriteGroupId,
       })
       if (reqId !== seriesLoadSeq || key !== seriesListRequestKey(get())) return
@@ -1176,6 +1245,7 @@ export const useStore = create((set, get) => ({
     if (total > 0 && baseOffset + loaded >= total) return
 
     const directoryIds = directoryQueryIds(state)
+    const closedSubdirs = closedSubdirectoryPairs(state)
     const search = state.javSearchTerm || ''
     const requestKey = seriesListRequestKey(state, directoryIds)
     const loadReqId = seriesLoadSeq
@@ -1187,6 +1257,7 @@ export const useStore = create((set, get) => ({
         offset: baseOffset + loaded,
         search,
         directoryIds,
+        closedSubdirs,
         favoriteGroupId: state.seriesFavoriteGroupId,
       })
       if (
@@ -1309,6 +1380,7 @@ export const useStore = create((set, get) => ({
     set({
       enabledDirectoryIds: mode === DIRECTORY_FILTER_ALL ? active : clean,
       directoryFilterMode: mode,
+      closedSubdirectories: pruneClosedSubdirectories(get().closedSubdirectories, clean),
       page: 1,
       javPage: 1,
       idolPage: 1,
@@ -1322,6 +1394,66 @@ export const useStore = create((set, get) => ({
       javRandomMode: false,
       javRandomSeed: null,
     })
+    lastVideoFetchKey = null
+    lastJavFetchKey = null
+    lastIdolFetchKey = null
+    lastStudioFetchKey = null
+    lastSeriesFetchKey = null
+    lastTagFetchKey = null
+    lastJavTagFetchKey = null
+  },
+  setClosedSubdirectories: (directoryId, names) => {
+    const id = Number(directoryId)
+    const cleanNames = Array.from(
+      new Set((names || []).map((name) => String(name || '').trim()).filter(Boolean))
+    ).sort((a, b) => a.localeCompare(b))
+    const state = get()
+    const next = { ...(state.closedSubdirectories || {}) }
+    if (cleanNames.length === 0) {
+      delete next[id]
+    } else {
+      next[id] = cleanNames
+    }
+    set({
+      closedSubdirectories: next,
+      page: 1,
+      javPage: 1,
+      idolPage: 1,
+      studioPage: 1,
+      seriesPage: 1,
+      videoTempSort: '',
+      javTempSort: '',
+      idolTempSort: '',
+      randomMode: false,
+      randomSeed: null,
+      javRandomMode: false,
+      javRandomSeed: null,
+    })
+    lastVideoFetchKey = null
+    lastJavFetchKey = null
+    lastIdolFetchKey = null
+    lastStudioFetchKey = null
+    lastSeriesFetchKey = null
+    lastTagFetchKey = null
+    lastJavTagFetchKey = null
+  },
+  setClosedSubdirectoriesFromUrl: (pairs) => {
+    const map = {}
+    for (const pair of Array.isArray(pairs) ? pairs : []) {
+      const id = Number(pair?.directoryId)
+      const name = String(pair?.name || '').trim()
+      if (!Number.isFinite(id) || id <= 0 || !name) continue
+      if (!map[id]) map[id] = []
+      if (!map[id].includes(name)) map[id].push(name)
+    }
+    const active = cleanDirectoryIds(get().directories.map((directory) => directory?.id))
+    const pruned = pruneClosedSubdirectories(map, active)
+    const state = get()
+    const current = state.closedSubdirectories || {}
+    if (JSON.stringify(current) === JSON.stringify(pruned)) {
+      return
+    }
+    set({ closedSubdirectories: pruned })
     lastVideoFetchKey = null
     lastJavFetchKey = null
     lastIdolFetchKey = null

--- a/web/src/utils/urlState.js
+++ b/web/src/utils/urlState.js
@@ -39,6 +39,22 @@ const parseDirectoryIds = (sp) => {
   return parseIds(raw)
 }
 
+const parseClosedSubdirs = (sp) => {
+  const raw = (sp.get('closed_subdirs') || '').trim()
+  if (!raw) return []
+  return raw
+    .split(',')
+    .map((part) => {
+      const idx = part.indexOf(':')
+      if (idx <= 0) return null
+      const id = Number.parseInt(part.slice(0, idx).trim(), 10)
+      const name = part.slice(idx + 1).trim()
+      if (!Number.isFinite(id) || id <= 0 || !name) return null
+      return { directoryId: id, name }
+    })
+    .filter(Boolean)
+}
+
 const parseIntSafe = (val, def = 1) => {
   const n = Number.parseInt(val || '', 10)
   return Number.isFinite(n) && n > 0 ? n : def
@@ -50,6 +66,7 @@ export const parseUrlState = (searchString = window.location.search, options = {
   const rawView = sp.get('view')
   const view = rawView === 'jav' ? 'jav' : rawView === 'video' ? 'video' : defaultView
   const directoryIds = parseDirectoryIds(sp)
+  const closedSubdirs = parseClosedSubdirs(sp)
 
   const videoTempSort = normalizeVideoSort((sp.get('temp_sort') || '').trim(), '')
 
@@ -94,7 +111,7 @@ export const parseUrlState = (searchString = window.location.search, options = {
     seed: clampSeed(sp.get('seed')),
   }
 
-  return { view, directoryIds, video, jav }
+  return { view, directoryIds, closedSubdirs, video, jav }
 }
 
 export const buildUrlFromState = (state, basePath = window.location.pathname) => {
@@ -105,6 +122,14 @@ export const buildUrlFromState = (state, basePath = window.location.pathname) =>
       sp.set('directory_ids', state.directoryIds.join(','))
     } else if (Array.isArray(state.directoryIds) && state.directoryIds.length === 0) {
       sp.set('directory_ids', '0')
+    }
+    if (state.closedSubdirs?.length) {
+      sp.set(
+        'closed_subdirs',
+        state.closedSubdirs
+          .map((pair) => `${Number(pair.directoryId)}:${pair.name}`)
+          .join(',')
+      )
     }
     if (state.jav.tab === 'idol' || state.jav.tab === 'studio' || state.jav.tab === 'series') {
       sp.set('tab', state.jav.tab)
@@ -166,6 +191,14 @@ export const buildUrlFromState = (state, basePath = window.location.pathname) =>
   } else if (Array.isArray(state.directoryIds) && state.directoryIds.length === 0) {
     sp.set('directory_ids', '0')
   }
+  if (state.closedSubdirs?.length) {
+    sp.set(
+      'closed_subdirs',
+      state.closedSubdirs
+        .map((pair) => `${Number(pair.directoryId)}:${pair.name}`)
+        .join(',')
+    )
+  }
   if (state.video.search) sp.set('search', state.video.search)
   if (!state.video.random && state.video.tempSort) sp.set('temp_sort', state.video.tempSort)
   if (state.video.tagIds?.length) {
@@ -211,10 +244,26 @@ export const normalizeUrlStateFromStore = (store, tagsByName) => {
       directoryIds = enabledDirectoryIds
     }
   }
+  const closedSubdirs = []
+  for (const [rawId, names] of Object.entries(store.closedSubdirectories || {})) {
+    const id = Number(rawId)
+    if (!Number.isFinite(id) || id <= 0 || !activeSet.has(id)) continue
+    if (!Array.isArray(names)) continue
+    for (const name of names) {
+      const clean = String(name || '').trim()
+      if (clean) closedSubdirs.push({ directoryId: id, name: clean })
+    }
+  }
+  closedSubdirs.sort((a, b) =>
+    a.directoryId === b.directoryId
+      ? a.name.localeCompare(b.name)
+      : a.directoryId - b.directoryId
+  )
 
   return {
     view: store.viewMode === 'jav' ? 'jav' : 'video',
     directoryIds,
+    closedSubdirs,
     video: {
       page: store.randomMode ? 1 : store.page,
       search: store.randomMode ? '' : (store.searchTerm || '').trim(),

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -4,5 +4,11 @@ export default {
   theme: {
     extend: {},
   },
-  plugins: [],
+  plugins: [
+    // Tailwind v3 没有内置 pointer-coarse 变体（v4 才有），这里手动注册：
+    // 匹配触摸设备（移动端），用于播放器移动端贴边全屏样式
+    ({ addVariant }) => {
+      addVariant('pointer-coarse', '@media (pointer: coarse)')
+    },
+  ],
 }


### PR DESCRIPTION
## 背景

右上角目录菜单此前只能整体启用/关闭主目录。本 PR 支持对目录下的任意层级子目录进行展开查看与勾选过滤。

## 变更内容

### 后端
- `GET /directories/:id/subdirectories` 改为返回完整目录树：每个节点包含相对根目录的完整路径（`path`）、子树文件数（`video_count`）、直接文件数（`direct_video_count`）与子节点（`subdirectories`），任意层级递归
- `closed_subdirs` 查询参数支持多级相对路径（如 `1:JAV/ABC`），前缀匹配过滤已贯通以下接口：`/videos`、`/jav`、`/tags`、`/jav/tags`、`/jav/idols`、`/jav/studios`、`/jav/series`
- 目录名中的特殊字符（`%`、`_`、引号）在 LIKE 过滤中已转义

### 前端（右上角目录菜单）
- 递归树渲染：每一层级右侧显示该层级文件数与展开/折叠箭头，任意层级可独立展开/收起
- 勾选控制：勾选节点 = 整棵子树内容显示；取消勾选 = 子树内容隐藏（记录完整路径）
- 父级半选（indeterminate）状态递归计算，包含"等效隐藏"节点（子级全部隐藏且自身无直接文件）
- 隐藏节点的最后一个子目录且自身无直接文件时，自动向上级联隐藏父级（直到目录级）；若目录根部仍有直接文件，则保持目录启用并显示"部分子目录已隐藏"标记
- 隐藏状态通过 `closed_subdirs` URL 参数持久化，刷新/分享链接不丢失

## 测试
- 新增后端测试：目录树构建（含嵌套层级）、多级关闭过滤、特殊字符目录名、HTTP 端点
- `internal/db` 全部测试通过（`go test ./internal/db/`）