### PR TITLE
feat: 支持按完整番号整理目录

### DIFF
--- a/internal/service/directory_processor.go
+++ b/internal/service/directory_processor.go
@@ -28,6 +28,7 @@ const (
 	DirectoryProcessOrganize            = "organize"
 	DirectoryProcessOrganizeWithSidecar = "organize_with_sidecar"
 	DirectoryProcessLayoutPrefix        = "prefix"
+	DirectoryProcessLayoutCode          = "code"
 	DirectoryProcessLayoutIdol          = "idol"
 	directoryOrganizeParent             = "JAV"
 	directoryUnknownIdol                = "未知女优"
@@ -146,6 +147,8 @@ func directoryProcessLayout(layout string) (string, bool) {
 	switch strings.TrimSpace(layout) {
 	case "", DirectoryProcessLayoutPrefix:
 		return DirectoryProcessLayoutPrefix, true
+	case DirectoryProcessLayoutCode:
+		return DirectoryProcessLayoutCode, true
 	case DirectoryProcessLayoutIdol:
 		return DirectoryProcessLayoutIdol, true
 	default:
@@ -225,13 +228,20 @@ func processJavItem(
 		target := source
 		if mode != DirectoryProcessSidecar {
 			group := prefix
-			if layout == DirectoryProcessLayoutIdol {
-				group = organizeIdolComponent(item.Idols)
+			if layout == DirectoryProcessLayoutCode {
+				target, err = safeDirectoryFilePath(
+					root,
+					filepath.Join(directoryOrganizeParent, code, filepath.Base(source)),
+				)
+			} else {
+				if layout == DirectoryProcessLayoutIdol {
+					group = organizeIdolComponent(item.Idols)
+				}
+				target, err = safeDirectoryFilePath(
+					root,
+					filepath.Join(directoryOrganizeParent, group, code, filepath.Base(source)),
+				)
 			}
-			target, err = safeDirectoryFilePath(
-				root,
-				filepath.Join(directoryOrganizeParent, group, code, filepath.Base(source)),
-			)
 			if err != nil {
 				summary.Failed++
 				logging.Error("resolve directory processing target failed path=%s err=%v", video.Path, err)

--- a/internal/service/directory_processor_test.go
+++ b/internal/service/directory_processor_test.go
@@ -118,6 +118,38 @@ func TestProcessJavItemOrganizesMediaWithoutRenaming(t *testing.T) {
 	}
 }
 
+func TestProcessJavItemOrganizesByCompleteCode(t *testing.T) {
+	root := t.TempDir()
+	videoName := "original-name.mp4"
+	writeTestFile(t, filepath.Join(root, videoName), []byte("video"))
+
+	item := models.Jav{
+		Code:   "ipx-001",
+		Videos: []models.Video{{Path: videoName}},
+	}
+	summary := &DirectoryProcessSummary{}
+	processJavItem(
+		t.Context(),
+		root,
+		&item,
+		DirectoryProcessOrganize,
+		DirectoryProcessLayoutCode,
+		"",
+		summary,
+	)
+
+	target := filepath.Join(root, "JAV", "IPX-001", videoName)
+	if _, err := os.Stat(target); err != nil {
+		t.Fatalf("complete-code organized video missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "JAV", "IPX")); !os.IsNotExist(err) {
+		t.Fatalf("prefix directory unexpectedly exists: %v", err)
+	}
+	if summary.Moved != 1 || summary.Failed != 0 {
+		t.Fatalf("summary = %+v, want one move and no failures", summary)
+	}
+}
+
 func TestProcessJavItemOrganizesAndWritesJellyfinSidecars(t *testing.T) {
 	root := t.TempDir()
 	coverDir := t.TempDir()

--- a/web/src/components/DirectoryManager.jsx
+++ b/web/src/components/DirectoryManager.jsx
@@ -11,6 +11,7 @@ const DIRECTORY_PROCESS_SIDECAR = 'sidecar'
 const DIRECTORY_PROCESS_ORGANIZE = 'organize'
 const DIRECTORY_PROCESS_ORGANIZE_WITH_SIDECAR = 'organize_with_sidecar'
 const DIRECTORY_PROCESS_LAYOUT_PREFIX = 'prefix'
+const DIRECTORY_PROCESS_LAYOUT_CODE = 'code'
 const DIRECTORY_PROCESS_LAYOUT_IDOL = 'idol'
 
 const directoryProcessOptions = () => [
@@ -45,6 +46,11 @@ const directoryProcessLayoutOptions = () => [
     layout: DIRECTORY_PROCESS_LAYOUT_PREFIX,
     title: zh('按番号前缀', 'By code prefix'),
     example: 'JAV/IPX/IPX-001/...',
+  },
+  {
+    layout: DIRECTORY_PROCESS_LAYOUT_CODE,
+    title: zh('������', 'By complete code'),
+    example: 'JAV/IPX-001/...',
   },
   {
     layout: DIRECTORY_PROCESS_LAYOUT_IDOL,

--- a/web/src/components/DirectoryManager.jsx
+++ b/web/src/components/DirectoryManager.jsx
@@ -49,7 +49,7 @@ const directoryProcessLayoutOptions = () => [
   },
   {
     layout: DIRECTORY_PROCESS_LAYOUT_CODE,
-    title: zh('������', 'By complete code'),
+    title: zh('按完整番号', 'By complete code'),
     example: 'JAV/IPX-001/...',
   },
   {


### PR DESCRIPTION
## 变更说明

新增目录整理方式：按完整番号创建一级目录。

- 原有 按番号前缀 保持不变：JAV/IPX/IPX-001/...
- 新增 按完整番号：JAV/IPX-001/...
- 原有 按女优 行为保持不变
- API 继续使用现有 layout 字段，无数据库变更

## 兼容性

这是新增选项，不改变默认布局或既有目录。选择新布局后，视频及匹配的字幕、封面、NFO 仍按现有整理逻辑处理并保留原文件名。

## 验证

- 新增 Go 单元测试，验证完整番号目标路径及不创建前缀目录
- 已执行 git diff --check
- 代码保留项目 GPL-3.0 许可证

请审阅并合并到 main。